### PR TITLE
Add scan_project tool + fix configure_server E2E flow (Issues #2, #3)

### DIFF
--- a/.claude/agent-memory/test-architect/MEMORY.md
+++ b/.claude/agent-memory/test-architect/MEMORY.md
@@ -1,11 +1,11 @@
-# Test Architect Memory — mcp-tap
+# Test Architect Memory -- mcp-tap
 
 ## Testing Setup
 - pytest + pytest-asyncio (asyncio_mode="auto")
 - Test dir: `tests/`
 - Run: `pytest tests/`
 - Linter: `ruff check src/ tests/`
-- Current: 119 tests passing (test_config, test_registry, test_models, test_scanner)
+- Current: 186 tests passing (test_config, test_registry, test_models, test_scanner, test_tools_scan, test_tools_configure)
 - Mock all external I/O (httpx, subprocess, filesystem)
 - Target: >80% coverage on new code
 
@@ -16,29 +16,43 @@
 - Unused unpacked vars must use `_` prefix (RUF059)
 - Line length: 100 chars
 - Python target: 3.11+
+- IMPORTANT: Run `ruff check --fix` after writing test files to auto-fix import sorting (I001)
 
 ## Test Patterns Established
 - Test classes grouped by component (e.g., TestParsePackageJson, TestScanFullPythonProject)
 - Fixtures stored in `tests/fixtures/` as realistic project directories
 - `tmp_path` fixture used for tests needing writable temp directories
 - Async test methods work directly (no decorator needed; asyncio_mode="auto")
-- Private functions tested directly via import (e.g., `_parse_package_json`)
+- Private functions tested directly via import (e.g., `_parse_package_json`, `_parse_env_vars`)
+- MCP Context mocked with: `ctx = MagicMock(); ctx.info = AsyncMock(); ctx.error = AsyncMock()`
+- Tool functions return `dict[str, object]` (serialized via `dataclasses.asdict`)
+- Patch targets at the module where imported, not where defined
 
 ## Fixture Projects Available
-- `tests/fixtures/python_fastapi_project/` — pyproject.toml, docker-compose.yml, .env.example, .github/
-- `tests/fixtures/node_express_project/` — package.json, docker-compose.yml, .env
-- `tests/fixtures/minimal_project/` — requirements.txt, Makefile
-- `tests/fixtures/empty_project/` — empty directory
+- `tests/fixtures/python_fastapi_project/` -- pyproject.toml, docker-compose.yml, .env.example, .github/
+- `tests/fixtures/node_express_project/` -- package.json, docker-compose.yml, .env
+- `tests/fixtures/minimal_project/` -- requirements.txt, Makefile
+- `tests/fixtures/empty_project/` -- empty directory
 
 ## Known Edge Cases
 - `_normalize_python_dep()` does NOT strip leading whitespace before regex split
-  (callers strip lines beforehand, so this is by design, not a bug)
 - Docker image matching uses substring search (`fragment in image_name`)
 - Env-pattern-detected techs get confidence=0.7 (lower than file-based detection)
 - `recommend_servers()` always adds filesystem-mcp recommendation
 
-## Scanner Module Structure
-- `src/mcp_tap/scanner/detector.py` — parsers + scan_project()
-- `src/mcp_tap/scanner/recommendations.py` — TECHNOLOGY_SERVER_MAP + recommend_servers()
-- `src/mcp_tap/models.py` — DetectedTechnology, ProjectProfile, ServerRecommendation, TechnologyCategory
-- `src/mcp_tap/errors.py` — ScanError
+## Tools Module Structure
+- `src/mcp_tap/tools/scan.py` -- scan_project tool (calls scanner, cross-refs installed)
+- `src/mcp_tap/tools/configure.py` -- configure_server tool (install -> write config -> validate)
+- `src/mcp_tap/errors.py` -- McpTapError hierarchy (ScanError, ConfigWriteError, InstallerNotFoundError, etc.)
+
+## Mock Patterns for Tools
+- Installer: `MagicMock()` with `install=AsyncMock(return_value=InstallResult(...))` and `build_server_command=MagicMock(return_value=(cmd, args))`
+- Connection tester: `AsyncMock(return_value=ConnectionTestResult(...))`
+- Config detection: `patch("mcp_tap.tools.X.detect_clients", return_value=[ConfigLocation(...)])`
+- Config writer: `patch("mcp_tap.tools.X.write_server_config")` -- verify called/not called
+- For scan tool: patch `_get_installed_server_names` to control installed set
+
+## ConfigureResult Model
+- Fields: success, server_name, config_file, message, config_written, install_status, tools_discovered, validation_passed
+- install_status values: "installed", "already_available", "skipped", "failed"
+- config_written from `ServerConfig.to_dict()` -- omits env when empty

--- a/docs/issues/2026-02-19_project-scanner-engine.md
+++ b/docs/issues/2026-02-19_project-scanner-engine.md
@@ -1,7 +1,7 @@
 # Project Scanner — File Detection Engine
 
 - **Date**: 2026-02-19
-- **Status**: `open`
+- **Status**: `done`
 - **Branch**: `feature/2026-02-19-project-scanner`
 - **Priority**: `critical`
 - **Issue**: #1

--- a/src/mcp_tap/models.py
+++ b/src/mcp_tap/models.py
@@ -134,6 +134,9 @@ class ConfigureResult:
     config_file: str
     message: str
     config_written: dict[str, object] = field(default_factory=dict)
+    install_status: str = ""  # installed / already_available / skipped / failed
+    tools_discovered: list[str] = field(default_factory=list)
+    validation_passed: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/mcp_tap/server.py
+++ b/src/mcp_tap/server.py
@@ -14,6 +14,7 @@ from mcp_tap.registry.client import RegistryClient
 from mcp_tap.tools.configure import configure_server
 from mcp_tap.tools.list import list_installed
 from mcp_tap.tools.remove import remove_server
+from mcp_tap.tools.scan import scan_project
 from mcp_tap.tools.search import search_servers
 from mcp_tap.tools.test import test_connection
 
@@ -41,14 +42,16 @@ mcp = FastMCP(
     "mcp-tap",
     instructions=(
         "This server helps you discover, install, and configure MCP servers. "
-        "Use search_servers to find servers, configure_server to add them to "
-        "your MCP client config, test_connection to verify they work, "
+        "Use scan_project to detect your tech stack and get recommendations, "
+        "search_servers to find servers, configure_server to install and add them "
+        "to your MCP client config, test_connection to verify they work, "
         "list_installed to see what's configured, and remove_server to clean up."
     ),
     lifespan=app_lifespan,
 )
 
 # ─── Read-only tools ──────────────────────────────────────────
+mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))(scan_project)
 mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))(search_servers)
 mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))(list_installed)
 mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))(test_connection)

--- a/src/mcp_tap/tools/configure.py
+++ b/src/mcp_tap/tools/configure.py
@@ -1,7 +1,8 @@
-"""configure_server tool -- add an MCP server to your client's config."""
+"""configure_server tool -- install, configure, and validate an MCP server."""
 
 from __future__ import annotations
 
+import logging
 from dataclasses import asdict
 from pathlib import Path
 
@@ -9,9 +10,18 @@ from mcp.server.fastmcp import Context
 
 from mcp_tap.config.detection import detect_clients, resolve_config_path
 from mcp_tap.config.writer import write_server_config
+from mcp_tap.connection.tester import test_server_connection
 from mcp_tap.errors import McpTapError
 from mcp_tap.installer.resolver import resolve_installer
-from mcp_tap.models import ConfigureResult, MCPClient, RegistryType, ServerConfig
+from mcp_tap.models import (
+    ConfigLocation,
+    ConfigureResult,
+    MCPClient,
+    RegistryType,
+    ServerConfig,
+)
+
+logger = logging.getLogger(__name__)
 
 
 async def configure_server(
@@ -20,12 +30,16 @@ async def configure_server(
     ctx: Context,
     client: str = "",
     registry_type: str = "npm",
+    version: str = "latest",
     env_vars: str = "",
 ) -> dict[str, object]:
-    """Add an MCP server to your AI client's configuration file.
+    """Install an MCP server package, add it to your client config, and verify it works.
 
-    Generates the correct JSON config and injects it into the config file
-    for your MCP client (Claude Desktop, Cursor, Claude Code, Windsurf).
+    Full end-to-end flow:
+    1. Resolves the package installer for the registry type
+    2. Installs/verifies the package (fails fast if install fails)
+    3. Writes the server entry to your MCP client config file
+    4. Validates the server by spawning it and calling list_tools()
 
     Args:
         server_name: Name for this server in the config (e.g. "postgres").
@@ -34,84 +48,152 @@ async def configure_server(
         client: Target MCP client. One of "claude_desktop", "claude_code",
             "cursor", "windsurf". If empty, auto-detects.
         registry_type: Package source -- "npm", "pypi", or "oci".
+        version: Package version to install. Defaults to "latest".
         env_vars: KEY=VALUE pairs separated by commas for environment
             variables the server needs
             (e.g. "POSTGRES_URL=postgresql://localhost/mydb,API_KEY=sk-...").
 
     Returns:
-        Configuration result showing what was written and where.
+        Configuration result showing install status, what was written,
+        validation results, and discovered tools.
     """
     try:
-        # Resolve client config path
-        if client:
-            location = resolve_config_path(MCPClient(client))
-        else:
-            clients = detect_clients()
-            if not clients:
-                return asdict(
-                    ConfigureResult(
-                        success=False,
-                        server_name=server_name,
-                        config_file="",
-                        message=(
-                            "No MCP client detected. Install Claude Desktop, "
-                            "Cursor, or Claude Code first."
-                        ),
-                    )
-                )
-            location = clients[0]
+        # Step 1: Resolve client config path
+        location = _resolve_client_location(client)
+        if location is None:
+            return asdict(ConfigureResult(
+                success=False,
+                server_name=server_name,
+                config_file="",
+                message=(
+                    "No MCP client detected. Install Claude Desktop, "
+                    "Cursor, or Claude Code first."
+                ),
+                install_status="skipped",
+            ))
 
-        # Build server config
+        # Step 2: Resolve installer and install the package
         rt = RegistryType(registry_type)
         installer = await resolve_installer(rt)
+
+        await ctx.info(f"Installing {package_identifier} via {rt.value}...")
+        install_result = await installer.install(package_identifier, version)
+
+        if not install_result.success:
+            return asdict(ConfigureResult(
+                success=False,
+                server_name=server_name,
+                config_file=location.path,
+                message=(
+                    f"Package installation failed: {install_result.message}. "
+                    "Config was NOT written to avoid a broken entry."
+                ),
+                install_status="failed",
+            ))
+
+        install_status = "installed"
+        logger.info("Package %s installed successfully", package_identifier)
+
+        # Step 3: Build server config and write atomically
         command, args = installer.build_server_command(package_identifier)
-
-        # Parse env vars
-        env: dict[str, str] = {}
-        if env_vars:
-            for pair in env_vars.split(","):
-                pair = pair.strip()
-                if "=" in pair:
-                    key, value = pair.split("=", 1)
-                    env[key.strip()] = value.strip()
-
+        env = _parse_env_vars(env_vars)
         server_config = ServerConfig(command=command, args=args, env=env)
 
-        # Write to config
         write_server_config(
             Path(location.path),
             server_name,
             server_config,
         )
 
-        return asdict(
-            ConfigureResult(
-                success=True,
-                server_name=server_name,
-                config_file=location.path,
-                message=(
-                    f"Server '{server_name}' added to {location.client.value} "
-                    f"config at {location.path}. Restart your MCP client to load it."
-                ),
-                config_written=server_config.to_dict(),
-            )
+        # Step 4: Validate the connection
+        tools_discovered: list[str] = []
+        validation_passed = False
+
+        await ctx.info(f"Validating {server_name} connection...")
+        test_result = await test_server_connection(
+            server_name,
+            server_config,
+            timeout_seconds=15,
         )
+
+        if test_result.success:
+            validation_passed = True
+            tools_discovered = list(test_result.tools_discovered)
+            tool_summary = (
+                f" Discovered {len(tools_discovered)} tools: "
+                f"{', '.join(tools_discovered[:10])}"
+                f"{'...' if len(tools_discovered) > 10 else ''}."
+            )
+        else:
+            tool_summary = (
+                f" Validation warning: {test_result.error}. "
+                "The server config was written. You may need to set "
+                "environment variables or restart your MCP client."
+            )
+            logger.warning(
+                "Validation failed for %s: %s",
+                server_name,
+                test_result.error,
+            )
+
+        return asdict(ConfigureResult(
+            success=True,
+            server_name=server_name,
+            config_file=location.path,
+            message=(
+                f"Server '{server_name}' installed and added to "
+                f"{location.client.value} config at {location.path}."
+                f"{tool_summary} "
+                "Restart your MCP client to load it."
+            ),
+            config_written=server_config.to_dict(),
+            install_status=install_status,
+            tools_discovered=tools_discovered,
+            validation_passed=validation_passed,
+        ))
+
     except McpTapError as exc:
-        return asdict(
-            ConfigureResult(
-                success=False,
-                server_name=server_name,
-                config_file="",
-                message=str(exc),
-            )
-        )
+        return asdict(ConfigureResult(
+            success=False,
+            server_name=server_name,
+            config_file="",
+            message=str(exc),
+            install_status="failed",
+        ))
     except Exception as exc:
         await ctx.error(f"Unexpected error in configure_server: {exc}")
-        return asdict(
-            ConfigureResult(
-                success=False,
-                server_name=server_name,
-                config_file="",
-                message=f"Internal error: {type(exc).__name__}",
-            )
-        )
+        return asdict(ConfigureResult(
+            success=False,
+            server_name=server_name,
+            config_file="",
+            message=f"Internal error: {type(exc).__name__}",
+            install_status="failed",
+        ))
+
+
+def _resolve_client_location(client: str) -> ConfigLocation | None:
+    """Resolve the config file location for the target MCP client.
+
+    Returns None if no client is detected and no explicit client was provided.
+    """
+    if client:
+        return resolve_config_path(MCPClient(client))
+
+    clients = detect_clients()
+    if not clients:
+        return None
+    return clients[0]
+
+
+def _parse_env_vars(env_vars: str) -> dict[str, str]:
+    """Parse comma-separated KEY=VALUE pairs into a dict."""
+    env: dict[str, str] = {}
+    if not env_vars:
+        return env
+
+    for pair in env_vars.split(","):
+        pair = pair.strip()
+        if "=" in pair:
+            key, value = pair.split("=", 1)
+            env[key.strip()] = value.strip()
+    return env

--- a/src/mcp_tap/tools/scan.py
+++ b/src/mcp_tap/tools/scan.py
@@ -1,0 +1,141 @@
+"""scan_project tool -- detect project technologies and recommend MCP servers."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+
+from mcp.server.fastmcp import Context
+
+from mcp_tap.config.detection import detect_clients, resolve_config_path
+from mcp_tap.config.reader import parse_servers, read_config
+from mcp_tap.errors import McpTapError
+from mcp_tap.models import MCPClient
+from mcp_tap.scanner.detector import scan_project as _scan_project
+
+
+async def scan_project(
+    ctx: Context,
+    path: str = ".",
+    client: str | None = None,
+) -> dict[str, object]:
+    """Scan a project directory to detect your tech stack and recommend MCP servers.
+
+    Analyzes project files (package.json, pyproject.toml, docker-compose.yml,
+    .env, etc.) to identify the technologies in use, then recommends MCP servers
+    that would be useful for that stack. Cross-references with your currently
+    installed servers to show what's missing.
+
+    Args:
+        path: Path to the project directory to scan. Defaults to ".".
+        client: Which MCP client's config to check for already-installed servers.
+            One of "claude_desktop", "claude_code", "cursor", "windsurf".
+            If not provided, auto-detects.
+
+    Returns:
+        Scan results with detected technologies, environment variables,
+        recommended MCP servers, and which ones are already installed.
+    """
+    try:
+        profile = await _scan_project(path)
+        installed_names = _get_installed_server_names(client)
+
+        # Cross-reference recommendations with installed servers
+        already_installed: list[str] = []
+        recommendations: list[dict[str, object]] = []
+        for rec in profile.recommendations:
+            is_installed = rec.server_name in installed_names
+            if is_installed:
+                already_installed.append(rec.server_name)
+            recommendations.append({
+                **asdict(rec),
+                "registry_type": rec.registry_type.value,
+                "already_installed": is_installed,
+            })
+
+        technologies = [
+            asdict(tech) | {"category": tech.category.value}
+            for tech in profile.technologies
+        ]
+
+        summary = _build_summary(
+            project_path=profile.path,
+            tech_count=len(profile.technologies),
+            rec_count=len(profile.recommendations),
+            installed_count=len(already_installed),
+            env_var_count=len(profile.env_var_names),
+        )
+
+        return {
+            "path": profile.path,
+            "detected_technologies": technologies,
+            "env_vars_found": profile.env_var_names,
+            "recommendations": recommendations,
+            "already_installed": already_installed,
+            "summary": summary,
+        }
+
+    except McpTapError as exc:
+        return {"success": False, "error": str(exc)}
+    except Exception as exc:
+        await ctx.error(f"Unexpected error in scan_project: {exc}")
+        return {"success": False, "error": f"Internal error: {type(exc).__name__}"}
+
+
+def _get_installed_server_names(client: str | None) -> set[str]:
+    """Read currently installed server names from the client config.
+
+    Returns an empty set if no client is detected or config is unreadable,
+    so that the scan still returns useful results.
+    """
+    try:
+        if client:
+            location = resolve_config_path(MCPClient(client))
+        else:
+            clients = detect_clients()
+            if not clients:
+                return set()
+            location = clients[0]
+
+        raw = read_config(Path(location.path))
+        servers = parse_servers(raw, source_file=location.path)
+        return {s.name for s in servers}
+    except Exception:
+        return set()
+
+
+def _build_summary(
+    *,
+    project_path: str,
+    tech_count: int,
+    rec_count: int,
+    installed_count: int,
+    env_var_count: int,
+) -> str:
+    """Build a human-readable summary string for LLM consumption."""
+    parts: list[str] = [
+        f"Scanned {project_path}.",
+        f"Detected {tech_count} technologies.",
+    ]
+
+    if env_var_count > 0:
+        parts.append(f"Found {env_var_count} environment variables.")
+
+    missing = rec_count - installed_count
+    if rec_count == 0:
+        parts.append("No MCP server recommendations for this stack.")
+    elif missing == 0:
+        parts.append(
+            f"All {rec_count} recommended MCP servers are already installed."
+        )
+    else:
+        parts.append(
+            f"{rec_count} MCP servers recommended, "
+            f"{installed_count} already installed, "
+            f"{missing} to add."
+        )
+        parts.append(
+            "Use configure_server to install the missing ones."
+        )
+
+    return " ".join(parts)

--- a/tests/test_tools_configure.py
+++ b/tests/test_tools_configure.py
@@ -1,0 +1,799 @@
+"""Tests for the configure_server MCP tool (tools/configure.py)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from mcp_tap.errors import ConfigWriteError, InstallerNotFoundError
+from mcp_tap.models import (
+    ConfigLocation,
+    ConnectionTestResult,
+    InstallResult,
+    MCPClient,
+    ServerConfig,
+)
+from mcp_tap.tools.configure import _parse_env_vars, _resolve_client_location, configure_server
+
+# ─── Helpers ─────────────────────────────────────────────────
+
+
+def _make_ctx() -> MagicMock:
+    """Build a mock Context with async info/error methods."""
+    ctx = MagicMock()
+    ctx.info = AsyncMock()
+    ctx.error = AsyncMock()
+    return ctx
+
+
+def _fake_location(
+    client: MCPClient = MCPClient.CLAUDE_CODE,
+    path: str = "/tmp/fake_config.json",
+    exists: bool = True,
+) -> ConfigLocation:
+    return ConfigLocation(client=client, path=path, scope="user", exists=exists)
+
+
+def _ok_install_result(identifier: str = "test-pkg") -> InstallResult:
+    return InstallResult(
+        success=True,
+        package_identifier=identifier,
+        install_method="npx",
+        message=f"Package {identifier} verified and cached by npx.",
+    )
+
+
+def _failed_install_result(identifier: str = "test-pkg") -> InstallResult:
+    return InstallResult(
+        success=False,
+        package_identifier=identifier,
+        install_method="npx",
+        message=f"Failed to verify {identifier}: package not found",
+        command_output="npm ERR! 404 Not Found",
+    )
+
+
+def _ok_connection_result(
+    server_name: str = "test-server",
+    tools: list[str] | None = None,
+) -> ConnectionTestResult:
+    return ConnectionTestResult(
+        success=True,
+        server_name=server_name,
+        tools_discovered=tools or ["read_query", "write_query", "create_table"],
+    )
+
+
+def _failed_connection_result(
+    server_name: str = "test-server",
+    error: str = "Server did not respond within 15s.",
+) -> ConnectionTestResult:
+    return ConnectionTestResult(
+        success=False,
+        server_name=server_name,
+        error=error,
+    )
+
+
+def _mock_installer(
+    install_result: InstallResult | None = None,
+    command: str = "npx",
+    args: list[str] | None = None,
+) -> MagicMock:
+    """Build a mock installer with configurable install result and command."""
+    installer = MagicMock()
+    installer.install = AsyncMock(return_value=install_result or _ok_install_result())
+    installer.build_server_command = MagicMock(
+        return_value=(command, args if args is not None else ["-y", "test-pkg"]),
+    )
+    installer.is_available = AsyncMock(return_value=True)
+    return installer
+
+
+# ═══════════════════════════════════════════════════════════════
+# Happy Path Tests
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestConfigureHappyPath:
+    """Tests for the full success flow: install -> write -> validate."""
+
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure._resolve_client_location")
+    async def test_full_success_flow(
+        self,
+        mock_location: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+    ):
+        """Should install, write config, validate, and return success."""
+        mock_location.return_value = _fake_location()
+        installer = _mock_installer()
+        mock_resolve_installer.return_value = installer
+        mock_test_conn.return_value = _ok_connection_result("pg-server")
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="pg-server",
+            package_identifier="@modelcontextprotocol/server-postgres",
+            ctx=ctx,
+            client="claude_code",
+            registry_type="npm",
+            env_vars="POSTGRES_URL=postgresql://localhost/db",
+        )
+
+        assert result["success"] is True
+        assert result["server_name"] == "pg-server"
+        assert result["config_file"] == "/tmp/fake_config.json"
+        assert result["install_status"] == "installed"
+        assert result["validation_passed"] is True
+        assert len(result["tools_discovered"]) == 3
+
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure._resolve_client_location")
+    async def test_config_written_contains_command_and_args(
+        self,
+        mock_location: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+    ):
+        """Should include config_written dict with command, args, env."""
+        mock_location.return_value = _fake_location()
+        mock_resolve_installer.return_value = _mock_installer()
+        mock_test_conn.return_value = _ok_connection_result()
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="test-server",
+            package_identifier="test-pkg",
+            ctx=ctx,
+            client="claude_code",
+            env_vars="KEY=value",
+        )
+
+        assert "config_written" in result
+        assert result["config_written"]["command"] == "npx"
+        assert result["config_written"]["args"] == ["-y", "test-pkg"]
+        assert result["config_written"]["env"] == {"KEY": "value"}
+
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure._resolve_client_location")
+    async def test_write_server_config_called_correctly(
+        self,
+        mock_location: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+    ):
+        """Should call write_server_config with correct path and config."""
+        loc = _fake_location(path="/home/user/.claude.json")
+        mock_location.return_value = loc
+        mock_resolve_installer.return_value = _mock_installer()
+        mock_test_conn.return_value = _ok_connection_result()
+
+        ctx = _make_ctx()
+        await configure_server(
+            server_name="my-server",
+            package_identifier="pkg",
+            ctx=ctx,
+            client="claude_code",
+        )
+
+        mock_write.assert_called_once()
+        call_args = mock_write.call_args
+        assert call_args[0][0] == Path("/home/user/.claude.json")
+        assert call_args[0][1] == "my-server"
+        assert isinstance(call_args[0][2], ServerConfig)
+
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure._resolve_client_location")
+    async def test_message_mentions_restart(
+        self,
+        mock_location: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+    ):
+        """Should tell user to restart their MCP client."""
+        mock_location.return_value = _fake_location()
+        mock_resolve_installer.return_value = _mock_installer()
+        mock_test_conn.return_value = _ok_connection_result()
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="s",
+            package_identifier="p",
+            ctx=ctx,
+            client="claude_code",
+        )
+
+        assert "Restart" in result["message"]
+
+
+# ═══════════════════════════════════════════════════════════════
+# Install Failure Tests
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestConfigureInstallFails:
+    """Tests for when package installation fails."""
+
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure._resolve_client_location")
+    async def test_install_failure_returns_error(
+        self,
+        mock_location: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+    ):
+        """Should return success=False when install fails."""
+        mock_location.return_value = _fake_location()
+        installer = _mock_installer(install_result=_failed_install_result("bad-pkg"))
+        mock_resolve_installer.return_value = installer
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="bad-server",
+            package_identifier="bad-pkg",
+            ctx=ctx,
+            client="claude_code",
+        )
+
+        assert result["success"] is False
+        assert result["install_status"] == "failed"
+        assert "installation failed" in result["message"].lower()
+
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure._resolve_client_location")
+    async def test_install_failure_does_not_write_config(
+        self,
+        mock_location: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+    ):
+        """Should NOT write config when install fails."""
+        mock_location.return_value = _fake_location()
+        installer = _mock_installer(install_result=_failed_install_result())
+        mock_resolve_installer.return_value = installer
+
+        ctx = _make_ctx()
+        await configure_server(
+            server_name="s",
+            package_identifier="p",
+            ctx=ctx,
+            client="claude_code",
+        )
+
+        mock_write.assert_not_called()
+
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure._resolve_client_location")
+    async def test_installer_not_found_returns_error(
+        self,
+        mock_location: MagicMock,
+        mock_resolve_installer: AsyncMock,
+    ):
+        """Should return error when package manager is not available."""
+        mock_location.return_value = _fake_location()
+        mock_resolve_installer.side_effect = InstallerNotFoundError(
+            "Package manager for npm is not installed."
+        )
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="s",
+            package_identifier="p",
+            ctx=ctx,
+            client="claude_code",
+        )
+
+        assert result["success"] is False
+        assert "not installed" in result["message"].lower()
+
+
+# ═══════════════════════════════════════════════════════════════
+# Validation Failure Tests
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestConfigureValidationFails:
+    """Tests for when install succeeds but validation fails."""
+
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure._resolve_client_location")
+    async def test_validation_failure_still_succeeds(
+        self,
+        mock_location: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+    ):
+        """Should return success=True even when validation fails (config is written)."""
+        mock_location.return_value = _fake_location()
+        mock_resolve_installer.return_value = _mock_installer()
+        mock_test_conn.return_value = _failed_connection_result("s", "timed out")
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="s",
+            package_identifier="p",
+            ctx=ctx,
+            client="claude_code",
+        )
+
+        assert result["success"] is True
+        assert result["validation_passed"] is False
+
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure._resolve_client_location")
+    async def test_validation_failure_config_still_written(
+        self,
+        mock_location: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+    ):
+        """Should still write config even when validation fails."""
+        mock_location.return_value = _fake_location()
+        mock_resolve_installer.return_value = _mock_installer()
+        mock_test_conn.return_value = _failed_connection_result()
+
+        ctx = _make_ctx()
+        await configure_server(
+            server_name="s",
+            package_identifier="p",
+            ctx=ctx,
+            client="claude_code",
+        )
+
+        mock_write.assert_called_once()
+
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure._resolve_client_location")
+    async def test_validation_failure_no_tools_discovered(
+        self,
+        mock_location: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+    ):
+        """Should return empty tools_discovered when validation fails."""
+        mock_location.return_value = _fake_location()
+        mock_resolve_installer.return_value = _mock_installer()
+        mock_test_conn.return_value = _failed_connection_result()
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="s",
+            package_identifier="p",
+            ctx=ctx,
+            client="claude_code",
+        )
+
+        assert result["tools_discovered"] == []
+
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure._resolve_client_location")
+    async def test_validation_failure_message_mentions_warning(
+        self,
+        mock_location: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+    ):
+        """Should include validation warning in the message."""
+        mock_location.return_value = _fake_location()
+        mock_resolve_installer.return_value = _mock_installer()
+        mock_test_conn.return_value = _failed_connection_result(error="Connection refused")
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="s",
+            package_identifier="p",
+            ctx=ctx,
+            client="claude_code",
+        )
+
+        assert "Validation warning" in result["message"]
+        assert "Connection refused" in result["message"]
+
+
+# ═══════════════════════════════════════════════════════════════
+# Result Field Tests
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestConfigureResultFields:
+    """Tests that ConfigureResult fields are properly populated."""
+
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure._resolve_client_location")
+    async def test_install_status_field(
+        self,
+        mock_location: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+    ):
+        """Should set install_status to 'installed' on success."""
+        mock_location.return_value = _fake_location()
+        mock_resolve_installer.return_value = _mock_installer()
+        mock_test_conn.return_value = _ok_connection_result()
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="s",
+            package_identifier="p",
+            ctx=ctx,
+            client="claude_code",
+        )
+
+        assert result["install_status"] == "installed"
+
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure._resolve_client_location")
+    async def test_tools_discovered_field(
+        self,
+        mock_location: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+    ):
+        """Should populate tools_discovered from validation result."""
+        mock_location.return_value = _fake_location()
+        mock_resolve_installer.return_value = _mock_installer()
+        mock_test_conn.return_value = _ok_connection_result(
+            tools=["read_query", "write_query"],
+        )
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="s",
+            package_identifier="p",
+            ctx=ctx,
+            client="claude_code",
+        )
+
+        assert result["tools_discovered"] == ["read_query", "write_query"]
+
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure._resolve_client_location")
+    async def test_validation_passed_true(
+        self,
+        mock_location: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+    ):
+        """Should set validation_passed=True when connection test succeeds."""
+        mock_location.return_value = _fake_location()
+        mock_resolve_installer.return_value = _mock_installer()
+        mock_test_conn.return_value = _ok_connection_result()
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="s",
+            package_identifier="p",
+            ctx=ctx,
+            client="claude_code",
+        )
+
+        assert result["validation_passed"] is True
+
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure._resolve_client_location")
+    async def test_result_is_plain_dict(
+        self,
+        mock_location: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+    ):
+        """Should return a plain dict (serialized via dataclasses.asdict)."""
+        mock_location.return_value = _fake_location()
+        mock_resolve_installer.return_value = _mock_installer()
+        mock_test_conn.return_value = _ok_connection_result()
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="s",
+            package_identifier="p",
+            ctx=ctx,
+            client="claude_code",
+        )
+
+        assert isinstance(result, dict)
+        # Verify all expected keys are present
+        expected_keys = {
+            "success", "server_name", "config_file", "message",
+            "config_written", "install_status", "tools_discovered",
+            "validation_passed",
+        }
+        assert expected_keys == set(result.keys())
+
+
+# ═══════════════════════════════════════════════════════════════
+# No Client Detected Tests
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestConfigureNoClient:
+    """Tests for when no MCP client is detected."""
+
+    @patch("mcp_tap.tools.configure._resolve_client_location", return_value=None)
+    async def test_no_client_returns_error(self, _mock_location: MagicMock):
+        """Should return success=False with helpful message."""
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="s",
+            package_identifier="p",
+            ctx=ctx,
+        )
+
+        assert result["success"] is False
+        assert "No MCP client detected" in result["message"]
+        assert result["install_status"] == "skipped"
+
+
+# ═══════════════════════════════════════════════════════════════
+# Env Var Parsing Tests
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestConfigureEnvVarParsing:
+    """Tests for env var parsing in configure_server."""
+
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure._resolve_client_location")
+    async def test_env_vars_parsed_into_config(
+        self,
+        mock_location: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+    ):
+        """Should parse comma-separated KEY=VALUE pairs into env dict."""
+        mock_location.return_value = _fake_location()
+        mock_resolve_installer.return_value = _mock_installer()
+        mock_test_conn.return_value = _ok_connection_result()
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="s",
+            package_identifier="p",
+            ctx=ctx,
+            client="claude_code",
+            env_vars="DB_URL=postgresql://localhost/db,API_KEY=sk-123",
+        )
+
+        written_env = result["config_written"].get("env", {})
+        assert written_env["DB_URL"] == "postgresql://localhost/db"
+        assert written_env["API_KEY"] == "sk-123"
+
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure._resolve_client_location")
+    async def test_empty_env_vars_no_env_in_config(
+        self,
+        mock_location: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+    ):
+        """Should not include env in config_written when env_vars is empty."""
+        mock_location.return_value = _fake_location()
+        mock_resolve_installer.return_value = _mock_installer()
+        mock_test_conn.return_value = _ok_connection_result()
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="s",
+            package_identifier="p",
+            ctx=ctx,
+            client="claude_code",
+            env_vars="",
+        )
+
+        # ServerConfig.to_dict() omits env when empty
+        assert "env" not in result["config_written"]
+
+
+# ═══════════════════════════════════════════════════════════════
+# Unexpected Exception Tests
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestConfigureUnexpectedErrors:
+    """Tests for unexpected exception handling."""
+
+    @patch(
+        "mcp_tap.tools.configure._resolve_client_location",
+        side_effect=RuntimeError("unexpected"),
+    )
+    async def test_unexpected_error_returns_dict(self, _mock_location: MagicMock):
+        """Should return error dict for unexpected exceptions."""
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="s",
+            package_identifier="p",
+            ctx=ctx,
+        )
+
+        assert result["success"] is False
+        assert "Internal error" in result["message"]
+        ctx.error.assert_awaited_once()
+
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure._resolve_client_location")
+    async def test_config_write_error_returns_mcptap_error(
+        self,
+        mock_location: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+    ):
+        """Should handle ConfigWriteError (server already exists)."""
+        mock_location.return_value = _fake_location()
+        mock_resolve_installer.return_value = _mock_installer()
+        mock_write.side_effect = ConfigWriteError("Server 'x' already exists")
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="x",
+            package_identifier="p",
+            ctx=ctx,
+            client="claude_code",
+        )
+
+        assert result["success"] is False
+        assert "already exists" in result["message"]
+
+
+# ═══════════════════════════════════════════════════════════════
+# PyPI Registry Type Tests
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestConfigurePypiRegistry:
+    """Tests for configuring a server from PyPI registry."""
+
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure._resolve_client_location")
+    async def test_pypi_registry_resolved(
+        self,
+        mock_location: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+    ):
+        """Should pass pypi RegistryType to resolve_installer."""
+        mock_location.return_value = _fake_location()
+        installer = _mock_installer(command="uvx", args=["some-mcp-server"])
+        mock_resolve_installer.return_value = installer
+        mock_test_conn.return_value = _ok_connection_result()
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="pypi-server",
+            package_identifier="some-mcp-server",
+            ctx=ctx,
+            client="claude_code",
+            registry_type="pypi",
+        )
+
+        mock_resolve_installer.assert_awaited_once()
+        # Verify the RegistryType.PYPI was passed
+        call_args = mock_resolve_installer.call_args[0]
+        from mcp_tap.models import RegistryType
+        assert call_args[0] == RegistryType.PYPI
+
+        assert result["success"] is True
+        assert result["config_written"]["command"] == "uvx"
+
+
+# ═══════════════════════════════════════════════════════════════
+# _parse_env_vars Unit Tests
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestParseEnvVars:
+    """Tests for the _parse_env_vars helper function."""
+
+    def test_empty_string(self):
+        """Should return empty dict for empty string."""
+        assert _parse_env_vars("") == {}
+
+    def test_single_pair(self):
+        """Should parse a single KEY=VALUE pair."""
+        assert _parse_env_vars("DB_URL=postgres://localhost") == {
+            "DB_URL": "postgres://localhost",
+        }
+
+    def test_multiple_pairs(self):
+        """Should parse comma-separated pairs."""
+        result = _parse_env_vars("KEY1=val1,KEY2=val2,KEY3=val3")
+        assert result == {"KEY1": "val1", "KEY2": "val2", "KEY3": "val3"}
+
+    def test_strips_whitespace(self):
+        """Should strip whitespace around keys and values."""
+        result = _parse_env_vars("  KEY = value , OTHER = stuff  ")
+        assert result == {"KEY": "value", "OTHER": "stuff"}
+
+    def test_value_with_equals_sign(self):
+        """Should handle values containing '=' (split on first only)."""
+        result = _parse_env_vars("URL=postgres://host?opt=true")
+        assert result == {"URL": "postgres://host?opt=true"}
+
+    def test_pair_without_equals_ignored(self):
+        """Should ignore entries without '=' sign."""
+        result = _parse_env_vars("KEY=val,BROKEN_ENTRY,OTHER=x")
+        assert result == {"KEY": "val", "OTHER": "x"}
+
+
+# ═══════════════════════════════════════════════════════════════
+# _resolve_client_location Unit Tests
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestResolveClientLocation:
+    """Tests for the _resolve_client_location helper function."""
+
+    @patch("mcp_tap.tools.configure.resolve_config_path")
+    def test_explicit_client(self, mock_resolve: MagicMock):
+        """Should call resolve_config_path for an explicit client."""
+        mock_resolve.return_value = _fake_location(client=MCPClient.CURSOR)
+
+        result = _resolve_client_location("cursor")
+        assert result is not None
+        mock_resolve.assert_called_once_with(MCPClient.CURSOR)
+
+    @patch("mcp_tap.tools.configure.detect_clients", return_value=[])
+    def test_no_clients_returns_none(self, _mock_detect: MagicMock):
+        """Should return None when no clients are detected."""
+        result = _resolve_client_location("")
+        assert result is None
+
+    @patch("mcp_tap.tools.configure.detect_clients")
+    def test_auto_detect_returns_first(self, mock_detect: MagicMock):
+        """Should return the first detected client."""
+        loc1 = _fake_location(client=MCPClient.CLAUDE_DESKTOP, path="/a")
+        loc2 = _fake_location(client=MCPClient.CURSOR, path="/b")
+        mock_detect.return_value = [loc1, loc2]
+
+        result = _resolve_client_location("")
+        assert result == loc1

--- a/tests/test_tools_scan.py
+++ b/tests/test_tools_scan.py
@@ -1,0 +1,503 @@
+"""Tests for the scan_project MCP tool (tools/scan.py)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from mcp_tap.models import ConfigLocation, MCPClient
+from mcp_tap.tools.scan import _build_summary, _get_installed_server_names, scan_project
+
+# ─── Fixture paths ───────────────────────────────────────────
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+PYTHON_FASTAPI = FIXTURES_DIR / "python_fastapi_project"
+NODE_EXPRESS = FIXTURES_DIR / "node_express_project"
+MINIMAL = FIXTURES_DIR / "minimal_project"
+EMPTY = FIXTURES_DIR / "empty_project"
+
+
+# ─── Helpers ─────────────────────────────────────────────────
+
+
+def _make_ctx() -> MagicMock:
+    """Build a mock Context with async info/error methods."""
+    ctx = MagicMock()
+    ctx.info = AsyncMock()
+    ctx.error = AsyncMock()
+    return ctx
+
+
+def _fake_location(
+    client: MCPClient = MCPClient.CLAUDE_CODE,
+    path: str = "/tmp/fake_config.json",
+    exists: bool = True,
+) -> ConfigLocation:
+    return ConfigLocation(client=client, path=path, scope="user", exists=exists)
+
+
+# ═══════════════════════════════════════════════════════════════
+# scan_project Tool Tests
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestScanReturnsTechnologies:
+    """Tests that scan_project detects technologies from fixture projects."""
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    async def test_python_fastapi_project(self, _mock_installed: MagicMock):
+        """Should detect Python, FastAPI, PostgreSQL, Redis from fixture."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(PYTHON_FASTAPI))
+
+        assert "detected_technologies" in result
+        tech_names = {t["name"] for t in result["detected_technologies"]}
+        assert "python" in tech_names
+        assert "fastapi" in tech_names
+        assert "postgresql" in tech_names
+        assert "redis" in tech_names
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    async def test_node_express_project(self, _mock_installed: MagicMock):
+        """Should detect Node.js, Express, PostgreSQL from fixture."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(NODE_EXPRESS))
+
+        tech_names = {t["name"] for t in result["detected_technologies"]}
+        assert "node.js" in tech_names
+        assert "express" in tech_names
+        assert "postgresql" in tech_names
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    async def test_technologies_have_category_as_string(self, _mock_installed: MagicMock):
+        """Should serialize category as a plain string, not StrEnum."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(PYTHON_FASTAPI))
+
+        for tech in result["detected_technologies"]:
+            assert isinstance(tech["category"], str)
+            assert tech["category"] in ("language", "framework", "database", "service", "platform")
+
+
+class TestScanReturnsRecommendations:
+    """Tests that scan_project populates recommendations."""
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    async def test_recommendations_populated(self, _mock_installed: MagicMock):
+        """Should return non-empty recommendations for a real project."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(PYTHON_FASTAPI))
+
+        assert "recommendations" in result
+        assert len(result["recommendations"]) > 0
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    async def test_postgres_recommendation_present(self, _mock_installed: MagicMock):
+        """Should recommend postgres-mcp for a project with PostgreSQL."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(PYTHON_FASTAPI))
+
+        rec_names = {r["server_name"] for r in result["recommendations"]}
+        assert "postgres-mcp" in rec_names
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    async def test_filesystem_always_recommended(self, _mock_installed: MagicMock):
+        """Should always include filesystem-mcp recommendation."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(MINIMAL))
+
+        rec_names = {r["server_name"] for r in result["recommendations"]}
+        assert "filesystem-mcp" in rec_names
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    async def test_recommendations_have_already_installed_field(
+        self, _mock_installed: MagicMock,
+    ):
+        """Should add 'already_installed' boolean to each recommendation."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(PYTHON_FASTAPI))
+
+        for rec in result["recommendations"]:
+            assert "already_installed" in rec
+            assert isinstance(rec["already_installed"], bool)
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    async def test_recommendations_have_registry_type_as_string(
+        self, _mock_installed: MagicMock,
+    ):
+        """Should serialize registry_type as a plain string."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(PYTHON_FASTAPI))
+
+        for rec in result["recommendations"]:
+            assert isinstance(rec["registry_type"], str)
+            assert rec["registry_type"] in ("npm", "pypi", "oci")
+
+
+class TestScanReturnsEnvVars:
+    """Tests that scan_project extracts environment variables."""
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    async def test_env_vars_from_python_project(self, _mock_installed: MagicMock):
+        """Should extract env var names from .env.example."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(PYTHON_FASTAPI))
+
+        assert "env_vars_found" in result
+        assert "DATABASE_URL" in result["env_vars_found"]
+        assert "REDIS_URL" in result["env_vars_found"]
+        assert "SLACK_BOT_TOKEN" in result["env_vars_found"]
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    async def test_env_vars_from_node_project(self, _mock_installed: MagicMock):
+        """Should extract env var names from .env file."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(NODE_EXPRESS))
+
+        assert "DATABASE_URL" in result["env_vars_found"]
+        assert "GITHUB_TOKEN" in result["env_vars_found"]
+
+
+class TestScanMarksAlreadyInstalled:
+    """Tests that scan cross-references with installed servers."""
+
+    @patch(
+        "mcp_tap.tools.scan._get_installed_server_names",
+        return_value={"postgres-mcp", "redis-mcp"},
+    )
+    async def test_marks_installed_servers(self, _mock_installed: MagicMock):
+        """Should mark matching recommendations as already_installed=True."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(PYTHON_FASTAPI))
+
+        installed_map = {
+            r["server_name"]: r["already_installed"] for r in result["recommendations"]
+        }
+        assert installed_map.get("postgres-mcp") is True
+        assert installed_map.get("redis-mcp") is True
+
+    @patch(
+        "mcp_tap.tools.scan._get_installed_server_names",
+        return_value={"postgres-mcp"},
+    )
+    async def test_marks_non_installed_servers(self, _mock_installed: MagicMock):
+        """Should mark non-installed recommendations as already_installed=False."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(PYTHON_FASTAPI))
+
+        installed_map = {
+            r["server_name"]: r["already_installed"] for r in result["recommendations"]
+        }
+        # filesystem-mcp is not in the installed set
+        assert installed_map.get("filesystem-mcp") is False
+
+    @patch(
+        "mcp_tap.tools.scan._get_installed_server_names",
+        return_value={"postgres-mcp", "redis-mcp"},
+    )
+    async def test_already_installed_list_populated(self, _mock_installed: MagicMock):
+        """Should populate the top-level 'already_installed' list."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(PYTHON_FASTAPI))
+
+        assert "already_installed" in result
+        assert "postgres-mcp" in result["already_installed"]
+        assert "redis-mcp" in result["already_installed"]
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    async def test_no_installed_servers(self, _mock_installed: MagicMock):
+        """Should have empty already_installed when nothing is installed."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(PYTHON_FASTAPI))
+
+        assert result["already_installed"] == []
+
+
+class TestScanEmptyProject:
+    """Tests for scanning an empty project directory."""
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    async def test_returns_valid_result(self, _mock_installed: MagicMock):
+        """Should return a valid dict for an empty project (no crash)."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(EMPTY))
+
+        assert "path" in result
+        assert "detected_technologies" in result
+        assert "recommendations" in result
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    async def test_no_technologies_detected(self, _mock_installed: MagicMock):
+        """Should detect no technologies in an empty project."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(EMPTY))
+
+        assert result["detected_technologies"] == []
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    async def test_no_env_vars(self, _mock_installed: MagicMock):
+        """Should have empty env_vars_found."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(EMPTY))
+
+        assert result["env_vars_found"] == []
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    async def test_only_filesystem_recommendation(self, _mock_installed: MagicMock):
+        """Should only recommend filesystem-mcp for an empty project."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(EMPTY))
+
+        assert len(result["recommendations"]) == 1
+        assert result["recommendations"][0]["server_name"] == "filesystem-mcp"
+
+
+class TestScanInvalidPath:
+    """Tests for scanning paths that don't exist."""
+
+    async def test_nonexistent_path_returns_error(self, tmp_path: Path):
+        """Should return error dict for nonexistent path, not raise."""
+        ctx = _make_ctx()
+        fake_path = str(tmp_path / "does_not_exist")
+        result = await scan_project(ctx, path=fake_path)
+
+        assert result.get("success") is False
+        assert "error" in result
+
+    async def test_file_path_returns_error(self, tmp_path: Path):
+        """Should return error dict when path is a file, not a directory."""
+        ctx = _make_ctx()
+        f = tmp_path / "not_a_dir.txt"
+        f.write_text("hello")
+        result = await scan_project(ctx, path=str(f))
+
+        assert result.get("success") is False
+        assert "error" in result
+
+    async def test_unexpected_exception_returns_error(self):
+        """Should catch unexpected exceptions and return error dict."""
+        ctx = _make_ctx()
+
+        with patch(
+            "mcp_tap.tools.scan._scan_project",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = await scan_project(ctx, path=str(PYTHON_FASTAPI))
+
+        assert result.get("success") is False
+        assert "Internal error" in result["error"]
+        ctx.error.assert_awaited_once()
+
+
+class TestScanDefaultPath:
+    """Tests for the default path parameter."""
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    @patch("mcp_tap.tools.scan._scan_project")
+    async def test_default_path_is_dot(
+        self, mock_scan: AsyncMock, _mock_installed: MagicMock,
+    ):
+        """Should pass '.' to the scanner when no path is specified."""
+        # We need to give scan_project a valid-looking profile to avoid errors
+        from mcp_tap.models import ProjectProfile
+
+        mock_scan.return_value = ProjectProfile(path="/resolved/path")
+
+        ctx = _make_ctx()
+        await scan_project(ctx)  # no path argument
+
+        mock_scan.assert_awaited_once_with(".")
+
+
+class TestScanHasSummary:
+    """Tests for the summary field in scan results."""
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    async def test_summary_is_nonempty_string(self, _mock_installed: MagicMock):
+        """Should include a non-empty summary string."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(PYTHON_FASTAPI))
+
+        assert "summary" in result
+        assert isinstance(result["summary"], str)
+        assert len(result["summary"]) > 0
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    async def test_summary_mentions_path(self, _mock_installed: MagicMock):
+        """Should mention the scanned path in the summary."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(PYTHON_FASTAPI))
+
+        # The resolved absolute path should be referenced
+        assert str(PYTHON_FASTAPI.resolve()) in result["summary"]
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    async def test_summary_mentions_technology_count(self, _mock_installed: MagicMock):
+        """Should mention the number of detected technologies."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(PYTHON_FASTAPI))
+
+        tech_count = len(result["detected_technologies"])
+        assert f"{tech_count} technologies" in result["summary"]
+
+    @patch(
+        "mcp_tap.tools.scan._get_installed_server_names",
+        return_value={"postgres-mcp", "redis-mcp"},
+    )
+    async def test_summary_mentions_installed_count(self, _mock_installed: MagicMock):
+        """Should mention how many servers are already installed."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(PYTHON_FASTAPI))
+
+        installed_count = len(result["already_installed"])
+        assert f"{installed_count} already installed" in result["summary"]
+
+    @patch("mcp_tap.tools.scan._get_installed_server_names", return_value=set())
+    async def test_summary_empty_project(self, _mock_installed: MagicMock):
+        """Should produce a valid summary for an empty project."""
+        ctx = _make_ctx()
+        result = await scan_project(ctx, path=str(EMPTY))
+
+        assert "0 technologies" in result["summary"]
+
+
+class TestScanClientParameter:
+    """Tests for the optional client parameter."""
+
+    @patch("mcp_tap.tools.scan._scan_project")
+    @patch("mcp_tap.tools.scan.resolve_config_path")
+    @patch("mcp_tap.tools.scan.read_config", return_value={"mcpServers": {}})
+    async def test_explicit_client_calls_resolve(
+        self,
+        _mock_read: MagicMock,
+        mock_resolve: MagicMock,
+        mock_scan: AsyncMock,
+    ):
+        """Should call resolve_config_path with the explicit client value."""
+        from mcp_tap.models import ProjectProfile
+
+        mock_resolve.return_value = _fake_location()
+        mock_scan.return_value = ProjectProfile(path="/tmp")
+
+        ctx = _make_ctx()
+        await scan_project(ctx, path=str(EMPTY), client="claude_code")
+
+        mock_resolve.assert_called_once_with(MCPClient.CLAUDE_CODE)
+
+
+# ═══════════════════════════════════════════════════════════════
+# _build_summary Unit Tests
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestBuildSummary:
+    """Tests for the _build_summary helper function."""
+
+    def test_basic_summary(self):
+        """Should produce a summary with path and tech count."""
+        summary = _build_summary(
+            project_path="/tmp/project",
+            tech_count=5,
+            rec_count=3,
+            installed_count=1,
+            env_var_count=2,
+        )
+        assert "/tmp/project" in summary
+        assert "5 technologies" in summary
+        assert "2 environment variables" in summary
+
+    def test_all_installed(self):
+        """Should mention 'all recommended' when all are installed."""
+        summary = _build_summary(
+            project_path="/p",
+            tech_count=2,
+            rec_count=3,
+            installed_count=3,
+            env_var_count=0,
+        )
+        assert "already installed" in summary.lower()
+
+    def test_no_recommendations(self):
+        """Should mention no recommendations when rec_count is 0."""
+        summary = _build_summary(
+            project_path="/p",
+            tech_count=0,
+            rec_count=0,
+            installed_count=0,
+            env_var_count=0,
+        )
+        assert "No MCP server recommendations" in summary
+
+    def test_missing_count(self):
+        """Should mention how many servers are missing."""
+        summary = _build_summary(
+            project_path="/p",
+            tech_count=3,
+            rec_count=5,
+            installed_count=2,
+            env_var_count=1,
+        )
+        assert "3 to add" in summary
+        assert "configure_server" in summary
+
+    def test_no_env_vars_omitted(self):
+        """Should not mention environment variables when count is 0."""
+        summary = _build_summary(
+            project_path="/p",
+            tech_count=1,
+            rec_count=1,
+            installed_count=0,
+            env_var_count=0,
+        )
+        assert "environment variable" not in summary
+
+
+# ═══════════════════════════════════════════════════════════════
+# _get_installed_server_names Unit Tests
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestGetInstalledServerNames:
+    """Tests for the _get_installed_server_names helper."""
+
+    @patch("mcp_tap.tools.scan.detect_clients", return_value=[])
+    def test_no_clients_returns_empty(self, _mock_detect: MagicMock):
+        """Should return empty set when no clients detected."""
+        result = _get_installed_server_names(None)
+        assert result == set()
+
+    @patch("mcp_tap.tools.scan.read_config")
+    @patch("mcp_tap.tools.scan.detect_clients")
+    def test_reads_from_detected_client(
+        self,
+        mock_detect: MagicMock,
+        mock_read: MagicMock,
+    ):
+        """Should read config from the first detected client."""
+        mock_detect.return_value = [_fake_location(path="/home/.claude.json")]
+        mock_read.return_value = {
+            "mcpServers": {
+                "postgres-mcp": {"command": "npx", "args": ["-y", "pg"]},
+                "github-mcp": {"command": "npx", "args": ["-y", "gh"]},
+            }
+        }
+
+        result = _get_installed_server_names(None)
+        assert result == {"postgres-mcp", "github-mcp"}
+
+    @patch("mcp_tap.tools.scan.read_config")
+    @patch("mcp_tap.tools.scan.resolve_config_path")
+    def test_explicit_client(self, mock_resolve: MagicMock, mock_read: MagicMock):
+        """Should use resolve_config_path when client is given explicitly."""
+        mock_resolve.return_value = _fake_location()
+        mock_read.return_value = {"mcpServers": {"my-server": {"command": "x"}}}
+
+        result = _get_installed_server_names("claude_code")
+        assert result == {"my-server"}
+        mock_resolve.assert_called_once()
+
+    @patch("mcp_tap.tools.scan.detect_clients", side_effect=Exception("filesystem error"))
+    def test_error_returns_empty_set(self, _mock_detect: MagicMock):
+        """Should return empty set on any error (graceful degradation)."""
+        result = _get_installed_server_names(None)
+        assert result == set()


### PR DESCRIPTION
## Summary
- New `scan_project` MCP tool — the core differentiator of mcp-tap
- Fixed `configure_server` to actually install packages and validate connections
- 67 new tests with full mocking of I/O boundaries

## scan_project (Issue #2)
- Scans a directory, detects tech stack, recommends MCP servers
- Cross-references with installed servers to show what's already set up
- Returns structured data + human-readable summary for the LLM
- Registered as `readOnlyHint=True`

## configure_server fix (Issue #3)
- **Before**: wrote config but never installed the package or validated
- **After**: install → write config → validate connection
- Failed installs abort without writing broken config entries
- ConfigureResult now carries install_status, tools_discovered, validation_passed

## Test plan
- [x] 186 tests passing (67 new + 119 existing)
- [x] `ruff check src/ tests/` — all checks passed
- [x] All external I/O mocked (no network, no filesystem writes in tests)