### PR TITLE
Add multi-client config + project-scoped configs (Issue #7)

### DIFF
--- a/docs/issues/2026-02-19_multi-client-config.md
+++ b/docs/issues/2026-02-19_multi-client-config.md
@@ -1,7 +1,7 @@
 # Multi-Client Config Support + Project-Scoped Configs
 
 - **Date**: 2026-02-19
-- **Status**: `open`
+- **Status**: `done`
 - **Branch**: `feature/2026-02-19-multi-client`
 - **Priority**: `medium`
 - **Issue**: #7
@@ -29,29 +29,53 @@
 
 3. **Project-scoped config paths**:
    - `.cursor/mcp.json` (Cursor project config)
-   - `.claude/mcp_servers.json` (Claude Code project config)
+   - `.mcp.json` (Claude Code project config)
+   - `.windsurf/mcp_config.json` (Windsurf project config)
    - Add `scope` parameter: "user" (global) or "project" (cwd)
-   - Default to "project" when detected, fallback to "user"
 
 4. **Tests**:
    - Multi-client configure + remove
    - Project-scoped vs user-scoped paths
 
-## Root Cause
-
-Initial implementation assumed single-client usage.
-
 ## Solution
 
-(Fill after implementation)
+### config/detection.py
+- Added `_PROJECT_CONFIGS` dict mapping clients → project-relative config paths
+- Added `resolve_config_locations(clients, scope, project_path)` — resolves one, many, or "all" clients for either user or project scope
+- Extended `resolve_config_path()` with `scope` and `project_path` keyword args
+- Added private helpers: `_resolve_project_config`, `_all_user_configs`, `_all_project_configs`
+- Claude Desktop correctly excluded from project-scoped configs (not supported)
+
+### tools/configure.py
+- Renamed `client` → `clients` param (comma-separated, "all", or empty for auto-detect)
+- Added `scope` and `project_path` params
+- Package install runs once, then config is written to each target client
+- Single client returns standard `ConfigureResult`; multi-client adds `per_client_results` list
+- Extracted `_configure_single`, `_configure_multi`, `_validate` helper functions
+
+### tools/remove.py
+- Same `clients`, `scope`, `project_path` params
+- Uses `resolve_config_locations` for client resolution
+- Multi-client returns `per_client_results` with per-client removal status
+- Correctly reports "not found in any" when server isn't in any config
+
+### Tests (18 new)
+- `test_detection.py` — 11 tests for `resolve_config_path` project scope + `resolve_config_locations`
+- Updated `test_tools_configure.py` — added 3 multi-client + 1 project-scope tests
+- Updated `test_tools_remove.py` — added 4 multi-client + 1 project-scope tests
 
 ## Files Changed
 
-(Fill after implementation)
+- `src/mcp_tap/config/detection.py` — Multi-client + project-scoped resolution
+- `src/mcp_tap/tools/configure.py` — Multi-client configure
+- `src/mcp_tap/tools/remove.py` — Multi-client remove
+- `tests/test_detection.py` — NEW (11 tests)
+- `tests/test_tools_configure.py` — Rewritten for new API (added multi-client + project scope)
+- `tests/test_tools_remove.py` — Rewritten for new API (added multi-client + project scope)
 
 ## Verification
 
-- [ ] Tests pass: `pytest tests/`
-- [ ] Linter passes: `ruff check src/ tests/`
-- [ ] Configure writes to multiple clients in one call
-- [ ] Project-scoped configs work for Cursor and Claude Code
+- [x] Tests pass: `pytest tests/` — 320 passed
+- [x] Linter passes: `ruff check src/ tests/`
+- [x] Configure writes to multiple clients in one call
+- [x] Project-scoped configs work for Cursor, Claude Code, and Windsurf

--- a/src/mcp_tap/config/detection.py
+++ b/src/mcp_tap/config/detection.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from mcp_tap.errors import ClientNotFoundError
 from mcp_tap.models import ConfigLocation, MCPClient
 
+# ─── User-scoped config paths ───────────────────────────────────
+
 
 def _claude_desktop_config() -> Path | None:
     home = Path.home()
@@ -45,6 +47,19 @@ _CLIENT_CONFIGS: list[tuple[MCPClient, str, callable]] = [
     (MCPClient.WINDSURF, "user", _windsurf_user_config),
 ]
 
+# ─── Project-scoped config paths ────────────────────────────────
+
+# Maps client → relative path inside project directory.
+# Claude Desktop has no project-scoped config.
+_PROJECT_CONFIGS: dict[MCPClient, str] = {
+    MCPClient.CLAUDE_CODE: ".mcp.json",
+    MCPClient.CURSOR: ".cursor/mcp.json",
+    MCPClient.WINDSURF: ".windsurf/mcp_config.json",
+}
+
+
+# ─── Public API ─────────────────────────────────────────────────
+
 
 def detect_clients() -> list[ConfigLocation]:
     """Detect all installed MCP clients and their config file locations.
@@ -68,12 +83,25 @@ def detect_clients() -> list[ConfigLocation]:
     return [loc for loc in found if loc.exists]
 
 
-def resolve_config_path(client: MCPClient | str) -> ConfigLocation:
-    """Resolve config path for a specific client.
+def resolve_config_path(
+    client: MCPClient | str,
+    *,
+    scope: str = "user",
+    project_path: str = "",
+) -> ConfigLocation:
+    """Resolve config path for a specific client and scope.
+
+    Args:
+        client: Target MCP client.
+        scope: "user" for global config, "project" for project-scoped.
+        project_path: Project directory (required when scope="project").
 
     Returns ConfigLocation even if the file doesn't exist yet (for first-time setup).
     """
     client_enum = MCPClient(client) if isinstance(client, str) else client
+
+    if scope == "project":
+        return _resolve_project_config(client_enum, project_path)
 
     path_map: dict[MCPClient, callable] = {
         MCPClient.CLAUDE_DESKTOP: _claude_desktop_config,
@@ -96,3 +124,99 @@ def resolve_config_path(client: MCPClient | str) -> ConfigLocation:
         scope="user",
         exists=path.exists(),
     )
+
+
+def resolve_config_locations(
+    clients: str = "",
+    *,
+    scope: str = "user",
+    project_path: str = "",
+) -> list[ConfigLocation]:
+    """Resolve config locations for one, many, or all clients.
+
+    Args:
+        clients: Comma-separated client names, "all", or empty for auto-detect.
+        scope: "user" for global config, "project" for project-scoped.
+        project_path: Project directory (required when scope="project").
+
+    Returns:
+        List of ConfigLocation entries. Empty list if no clients resolved.
+    """
+    if clients == "all":
+        if scope == "project":
+            return _all_project_configs(project_path)
+        return _all_user_configs()
+
+    if clients:
+        names = [c.strip() for c in clients.split(",") if c.strip()]
+        return [resolve_config_path(name, scope=scope, project_path=project_path) for name in names]
+
+    # Auto-detect: single best client
+    detected = detect_clients()
+    if not detected:
+        return []
+    return [detected[0]]
+
+
+# ─── Private helpers ────────────────────────────────────────────
+
+
+def _resolve_project_config(client: MCPClient, project_path: str) -> ConfigLocation:
+    """Resolve a project-scoped config path for a client."""
+    if not project_path:
+        raise ClientNotFoundError(
+            "project_path is required when scope='project'. "
+            "Pass the path to your project directory."
+        )
+
+    rel = _PROJECT_CONFIGS.get(client)
+    if rel is None:
+        raise ClientNotFoundError(
+            f"{client.value} does not support project-scoped config. Use scope='user' instead."
+        )
+
+    path = Path(project_path) / rel
+    return ConfigLocation(
+        client=client,
+        path=str(path),
+        scope="project",
+        exists=path.exists(),
+    )
+
+
+def _all_user_configs() -> list[ConfigLocation]:
+    """Return user-scoped config locations for all known clients."""
+    locations: list[ConfigLocation] = []
+    for client, _scope, path_fn in _CLIENT_CONFIGS:
+        path = path_fn()
+        if path is not None:
+            locations.append(
+                ConfigLocation(
+                    client=client,
+                    path=str(path),
+                    scope="user",
+                    exists=path.exists(),
+                )
+            )
+    return locations
+
+
+def _all_project_configs(project_path: str) -> list[ConfigLocation]:
+    """Return project-scoped config locations for all supported clients."""
+    if not project_path:
+        raise ClientNotFoundError(
+            "project_path is required when scope='project' and clients='all'."
+        )
+
+    locations: list[ConfigLocation] = []
+    for client, rel in _PROJECT_CONFIGS.items():
+        path = Path(project_path) / rel
+        locations.append(
+            ConfigLocation(
+                client=client,
+                path=str(path),
+                scope="project",
+                exists=path.exists(),
+            )
+        )
+    return locations

--- a/src/mcp_tap/tools/configure.py
+++ b/src/mcp_tap/tools/configure.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from mcp.server.fastmcp import Context
 
-from mcp_tap.config.detection import detect_clients, resolve_config_path
+from mcp_tap.config.detection import resolve_config_locations
 from mcp_tap.config.writer import write_server_config
 from mcp_tap.connection.tester import test_server_connection
 from mcp_tap.errors import McpTapError
@@ -16,7 +16,6 @@ from mcp_tap.installer.resolver import resolve_installer
 from mcp_tap.models import (
     ConfigLocation,
     ConfigureResult,
-    MCPClient,
     RegistryType,
     ServerConfig,
 )
@@ -28,39 +27,46 @@ async def configure_server(
     server_name: str,
     package_identifier: str,
     ctx: Context,
-    client: str = "",
+    clients: str = "",
     registry_type: str = "npm",
     version: str = "latest",
     env_vars: str = "",
+    scope: str = "user",
+    project_path: str = "",
 ) -> dict[str, object]:
     """Install an MCP server package, add it to your client config, and verify it works.
 
     Full end-to-end flow:
     1. Resolves the package installer for the registry type
     2. Installs/verifies the package (fails fast if install fails)
-    3. Writes the server entry to your MCP client config file
+    3. Writes the server entry to your MCP client config file(s)
     4. Validates the server by spawning it and calling list_tools()
 
     Args:
         server_name: Name for this server in the config (e.g. "postgres").
         package_identifier: The package to run
             (e.g. "@modelcontextprotocol/server-postgres").
-        client: Target MCP client. One of "claude_desktop", "claude_code",
-            "cursor", "windsurf". If empty, auto-detects.
+        clients: Target MCP client(s). Comma-separated names like
+            "claude_desktop,cursor", "all" for every detected client,
+            or empty to auto-detect the first available.
         registry_type: Package source -- "npm", "pypi", or "oci".
         version: Package version to install. Defaults to "latest".
         env_vars: KEY=VALUE pairs separated by commas for environment
             variables the server needs
             (e.g. "POSTGRES_URL=postgresql://localhost/mydb,API_KEY=sk-...").
+        scope: "user" for global config (default), "project" for
+            project-scoped config (e.g. .cursor/mcp.json in the project dir).
+        project_path: Path to the project directory. Required when scope="project".
 
     Returns:
         Configuration result showing install status, what was written,
-        validation results, and discovered tools.
+        validation results, and discovered tools. When configuring
+        multiple clients, includes per_client_results.
     """
     try:
-        # Step 1: Resolve client config path
-        location = _resolve_client_location(client)
-        if location is None:
+        # Step 1: Resolve target config locations
+        locations = resolve_config_locations(clients, scope=scope, project_path=project_path)
+        if not locations:
             return asdict(
                 ConfigureResult(
                     success=False,
@@ -74,7 +80,7 @@ async def configure_server(
                 )
             )
 
-        # Step 2: Resolve installer and install the package
+        # Step 2: Resolve installer and install the package (once)
         rt = RegistryType(registry_type)
         installer = await resolve_installer(rt)
 
@@ -86,7 +92,7 @@ async def configure_server(
                 ConfigureResult(
                     success=False,
                     server_name=server_name,
-                    config_file=location.path,
+                    config_file="",
                     message=(
                         f"Package installation failed: {install_result.message}. "
                         "Config was NOT written to avoid a broken entry."
@@ -95,68 +101,18 @@ async def configure_server(
                 )
             )
 
-        install_status = "installed"
         logger.info("Package %s installed successfully", package_identifier)
 
-        # Step 3: Build server config and write atomically
+        # Step 3: Build server config
         command, args = installer.build_server_command(package_identifier)
         env = _parse_env_vars(env_vars)
         server_config = ServerConfig(command=command, args=args, env=env)
 
-        write_server_config(
-            Path(location.path),
-            server_name,
-            server_config,
-        )
+        # Step 4: Write config to each target client
+        if len(locations) == 1:
+            return await _configure_single(server_name, server_config, locations[0], ctx)
 
-        # Step 4: Validate the connection
-        tools_discovered: list[str] = []
-        validation_passed = False
-
-        await ctx.info(f"Validating {server_name} connection...")
-        test_result = await test_server_connection(
-            server_name,
-            server_config,
-            timeout_seconds=15,
-        )
-
-        if test_result.success:
-            validation_passed = True
-            tools_discovered = list(test_result.tools_discovered)
-            tool_summary = (
-                f" Discovered {len(tools_discovered)} tools: "
-                f"{', '.join(tools_discovered[:10])}"
-                f"{'...' if len(tools_discovered) > 10 else ''}."
-            )
-        else:
-            tool_summary = (
-                f" Validation warning: {test_result.error}. "
-                "The server config was written. You may need to set "
-                "environment variables or restart your MCP client."
-            )
-            logger.warning(
-                "Validation failed for %s: %s",
-                server_name,
-                test_result.error,
-            )
-
-        return asdict(
-            ConfigureResult(
-                success=True,
-                server_name=server_name,
-                config_file=location.path,
-                message=(
-                    f"Server '{server_name}' installed and added to "
-                    f"{location.client.value} config at {location.path}."
-                    f"{tool_summary} "
-                    "Restart your MCP client to load it."
-                ),
-                config_written=server_config.to_dict(),
-                install_status=install_status,
-                tools_discovered=tools_discovered,
-                validation_passed=validation_passed,
-            )
-        )
+        return await _configure_multi(server_name, server_config, locations, ctx)
 
     except McpTapError as exc:
         return asdict(
@@ -181,18 +137,125 @@ async def configure_server(
         )
 
 
-def _resolve_client_location(client: str) -> ConfigLocation | None:
-    """Resolve the config file location for the target MCP client.
+async def _configure_single(
+    server_name: str,
+    server_config: ServerConfig,
+    location: ConfigLocation,
+    ctx: Context,
+) -> dict[str, object]:
+    """Configure a server for a single client. Returns a ConfigureResult dict."""
+    write_server_config(Path(location.path), server_name, server_config)
 
-    Returns None if no client is detected and no explicit client was provided.
-    """
-    if client:
-        return resolve_config_path(MCPClient(client))
+    # Validate the connection
+    tools_discovered, validation_passed, tool_summary = await _validate(
+        server_name, server_config, ctx
+    )
 
-    clients = detect_clients()
-    if not clients:
-        return None
-    return clients[0]
+    return asdict(
+        ConfigureResult(
+            success=True,
+            server_name=server_name,
+            config_file=location.path,
+            message=(
+                f"Server '{server_name}' installed and added to "
+                f"{location.client.value} ({location.scope}) at {location.path}."
+                f"{tool_summary} "
+                "Restart your MCP client to load it."
+            ),
+            config_written=server_config.to_dict(),
+            install_status="installed",
+            tools_discovered=tools_discovered,
+            validation_passed=validation_passed,
+        )
+    )
+
+
+async def _configure_multi(
+    server_name: str,
+    server_config: ServerConfig,
+    locations: list[ConfigLocation],
+    ctx: Context,
+) -> dict[str, object]:
+    """Configure a server for multiple clients. Returns aggregated result."""
+    # Validate once (same binary, same config)
+    tools_discovered, validation_passed, tool_summary = await _validate(
+        server_name, server_config, ctx
+    )
+
+    per_client: list[dict[str, object]] = []
+    success_count = 0
+
+    for loc in locations:
+        try:
+            write_server_config(Path(loc.path), server_name, server_config)
+            per_client.append(
+                {
+                    "client": loc.client.value,
+                    "scope": loc.scope,
+                    "config_file": loc.path,
+                    "success": True,
+                }
+            )
+            success_count += 1
+        except McpTapError as exc:
+            per_client.append(
+                {
+                    "client": loc.client.value,
+                    "scope": loc.scope,
+                    "config_file": loc.path,
+                    "success": False,
+                    "error": str(exc),
+                }
+            )
+
+    overall_success = success_count > 0
+    clients_ok = [r["client"] for r in per_client if r["success"]]
+
+    result = asdict(
+        ConfigureResult(
+            success=overall_success,
+            server_name=server_name,
+            config_file=", ".join(r["config_file"] for r in per_client if r["success"]),
+            message=(
+                f"Server '{server_name}' configured in {success_count}/{len(locations)} "
+                f"clients ({', '.join(clients_ok)}).{tool_summary} "
+                "Restart your MCP clients to load it."
+            ),
+            config_written=server_config.to_dict(),
+            install_status="installed",
+            tools_discovered=tools_discovered,
+            validation_passed=validation_passed,
+        )
+    )
+    result["per_client_results"] = per_client
+    return result
+
+
+async def _validate(
+    server_name: str,
+    server_config: ServerConfig,
+    ctx: Context,
+) -> tuple[list[str], bool, str]:
+    """Validate a server connection. Returns (tools, passed, summary_text)."""
+    await ctx.info(f"Validating {server_name} connection...")
+    test_result = await test_server_connection(server_name, server_config, timeout_seconds=15)
+
+    if test_result.success:
+        tools = list(test_result.tools_discovered)
+        summary = (
+            f" Discovered {len(tools)} tools: "
+            f"{', '.join(tools[:10])}"
+            f"{'...' if len(tools) > 10 else ''}."
+        )
+        return tools, True, summary
+
+    logger.warning("Validation failed for %s: %s", server_name, test_result.error)
+    summary = (
+        f" Validation warning: {test_result.error}. "
+        "The server config was written. You may need to set "
+        "environment variables or restart your MCP client."
+    )
+    return [], False, summary
 
 
 def _parse_env_vars(env_vars: str) -> dict[str, str]:

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1,0 +1,125 @@
+"""Tests for config/detection.py — multi-client + project-scoped config resolution."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from mcp_tap.config.detection import (
+    resolve_config_locations,
+    resolve_config_path,
+)
+from mcp_tap.errors import ClientNotFoundError
+from mcp_tap.models import MCPClient
+
+# ═══════════════════════════════════════════════════════════════
+# resolve_config_path — project scope
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestResolveConfigPathProjectScope:
+    def test_cursor_project_path(self):
+        loc = resolve_config_path(MCPClient.CURSOR, scope="project", project_path="/my/project")
+        assert loc.client == MCPClient.CURSOR
+        assert loc.path == "/my/project/.cursor/mcp.json"
+        assert loc.scope == "project"
+
+    def test_claude_code_project_path(self):
+        loc = resolve_config_path(
+            MCPClient.CLAUDE_CODE, scope="project", project_path="/my/project"
+        )
+        assert loc.path == "/my/project/.mcp.json"
+        assert loc.scope == "project"
+
+    def test_windsurf_project_path(self):
+        loc = resolve_config_path(MCPClient.WINDSURF, scope="project", project_path="/my/project")
+        assert loc.path == "/my/project/.windsurf/mcp_config.json"
+        assert loc.scope == "project"
+
+    def test_claude_desktop_no_project_scope(self):
+        with pytest.raises(ClientNotFoundError, match="does not support project-scoped"):
+            resolve_config_path(MCPClient.CLAUDE_DESKTOP, scope="project", project_path="/project")
+
+    def test_project_scope_requires_project_path(self):
+        with pytest.raises(ClientNotFoundError, match="project_path is required"):
+            resolve_config_path(MCPClient.CURSOR, scope="project", project_path="")
+
+    def test_user_scope_still_works(self):
+        loc = resolve_config_path(MCPClient.CURSOR, scope="user")
+        assert loc.scope == "user"
+        assert ".cursor/mcp.json" in loc.path
+
+
+# ═══════════════════════════════════════════════════════════════
+# resolve_config_locations
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestResolveConfigLocations:
+    def test_single_client_string(self):
+        locs = resolve_config_locations("cursor")
+        assert len(locs) == 1
+        assert locs[0].client == MCPClient.CURSOR
+
+    def test_comma_separated_clients(self):
+        locs = resolve_config_locations("cursor,windsurf")
+        assert len(locs) == 2
+        assert {loc.client for loc in locs} == {MCPClient.CURSOR, MCPClient.WINDSURF}
+
+    def test_all_user_returns_all_known(self):
+        locs = resolve_config_locations("all")
+        clients = {loc.client for loc in locs}
+        assert MCPClient.CLAUDE_DESKTOP in clients
+        assert MCPClient.CLAUDE_CODE in clients
+        assert MCPClient.CURSOR in clients
+        assert MCPClient.WINDSURF in clients
+
+    def test_all_project_returns_supported_only(self):
+        locs = resolve_config_locations("all", scope="project", project_path="/proj")
+        clients = {loc.client for loc in locs}
+        # Claude Desktop does NOT support project scope
+        assert MCPClient.CLAUDE_DESKTOP not in clients
+        assert MCPClient.CLAUDE_CODE in clients
+        assert MCPClient.CURSOR in clients
+        assert MCPClient.WINDSURF in clients
+
+    def test_all_project_requires_path(self):
+        with pytest.raises(ClientNotFoundError, match="project_path is required"):
+            resolve_config_locations("all", scope="project", project_path="")
+
+    @patch("mcp_tap.config.detection.detect_clients")
+    def test_empty_auto_detects(self, mock_detect):
+        from mcp_tap.models import ConfigLocation
+
+        mock_detect.return_value = [
+            ConfigLocation(
+                client=MCPClient.CURSOR,
+                path="/home/.cursor/mcp.json",
+                scope="user",
+                exists=True,
+            )
+        ]
+
+        locs = resolve_config_locations("")
+        assert len(locs) == 1
+        assert locs[0].client == MCPClient.CURSOR
+
+    @patch("mcp_tap.config.detection.detect_clients", return_value=[])
+    def test_empty_no_clients_returns_empty(self, _mock):
+        locs = resolve_config_locations("")
+        assert locs == []
+
+    def test_project_scope_single_client(self):
+        locs = resolve_config_locations("cursor", scope="project", project_path="/proj")
+        assert len(locs) == 1
+        assert locs[0].path == "/proj/.cursor/mcp.json"
+        assert locs[0].scope == "project"
+
+    def test_whitespace_in_clients_trimmed(self):
+        locs = resolve_config_locations(" cursor , windsurf ")
+        assert len(locs) == 2
+
+    def test_invalid_client_raises(self):
+        with pytest.raises(ValueError):
+            resolve_config_locations("not_a_client")

--- a/tests/test_tools_remove.py
+++ b/tests/test_tools_remove.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from mcp_tap.errors import McpTapError
+from mcp_tap.errors import ConfigWriteError, McpTapError
 from mcp_tap.models import ConfigLocation, MCPClient
 from mcp_tap.tools.remove import remove_server
 
@@ -21,32 +21,31 @@ def _make_ctx() -> MagicMock:
 def _fake_location(
     client: MCPClient = MCPClient.CLAUDE_CODE,
     path: str = "/tmp/fake_config.json",
+    scope: str = "user",
 ) -> ConfigLocation:
-    return ConfigLocation(client=client, path=path, scope="user", exists=True)
+    return ConfigLocation(client=client, path=path, scope=scope, exists=True)
 
 
-# --- remove_server tests --------------------------------------------------
+# --- Single client tests --------------------------------------------------
 
 
-class TestRemoveServer:
+class TestRemoveServerSingle:
     @patch("mcp_tap.tools.remove.remove_server_config")
-    @patch("mcp_tap.tools.remove.resolve_config_path")
-    async def test_successful_removal_explicit_client(self, mock_resolve, mock_remove):
-        mock_resolve.return_value = _fake_location()
+    @patch("mcp_tap.tools.remove.resolve_config_locations")
+    async def test_successful_removal_explicit_client(self, mock_locations, mock_remove):
+        mock_locations.return_value = [_fake_location()]
         mock_remove.return_value = {"command": "npx", "args": ["-y", "my-server"]}
 
-        result = await remove_server("my-server", _make_ctx(), client="claude_code")
+        result = await remove_server("my-server", _make_ctx(), clients="claude_code")
 
         assert result["success"] is True
         assert result["server_name"] == "my-server"
         assert "removed" in result["message"].lower()
-        mock_resolve.assert_called_once_with(MCPClient("claude_code"))
-        mock_remove.assert_called_once()
 
     @patch("mcp_tap.tools.remove.remove_server_config")
-    @patch("mcp_tap.tools.remove.detect_clients")
-    async def test_successful_removal_auto_detect(self, mock_detect, mock_remove):
-        mock_detect.return_value = [_fake_location()]
+    @patch("mcp_tap.tools.remove.resolve_config_locations")
+    async def test_successful_removal_auto_detect(self, mock_locations, mock_remove):
+        mock_locations.return_value = [_fake_location()]
         mock_remove.return_value = {"command": "npx"}
 
         result = await remove_server("my-server", _make_ctx())
@@ -54,9 +53,9 @@ class TestRemoveServer:
         assert result["success"] is True
         assert result["server_name"] == "my-server"
 
-    @patch("mcp_tap.tools.remove.detect_clients")
-    async def test_no_client_detected(self, mock_detect):
-        mock_detect.return_value = []
+    @patch("mcp_tap.tools.remove.resolve_config_locations")
+    async def test_no_client_detected(self, mock_locations):
+        mock_locations.return_value = []
 
         result = await remove_server("my-server", _make_ctx())
 
@@ -64,53 +63,138 @@ class TestRemoveServer:
         assert "No MCP client detected" in result["message"]
 
     @patch("mcp_tap.tools.remove.remove_server_config")
-    @patch("mcp_tap.tools.remove.resolve_config_path")
-    async def test_server_not_found(self, mock_resolve, mock_remove):
-        mock_resolve.return_value = _fake_location()
+    @patch("mcp_tap.tools.remove.resolve_config_locations")
+    async def test_server_not_found(self, mock_locations, mock_remove):
+        mock_locations.return_value = [_fake_location()]
         mock_remove.return_value = None
 
-        result = await remove_server("nonexistent", _make_ctx(), client="claude_code")
+        result = await remove_server("nonexistent", _make_ctx(), clients="claude_code")
 
         assert result["success"] is False
         assert "not found" in result["message"].lower()
         assert "list_installed" in result["message"]
 
-    @patch("mcp_tap.tools.remove.resolve_config_path")
-    async def test_mcp_tap_error(self, mock_resolve):
-        mock_resolve.side_effect = McpTapError("Permission denied")
+    @patch("mcp_tap.tools.remove.resolve_config_locations")
+    async def test_mcp_tap_error(self, mock_locations):
+        mock_locations.side_effect = McpTapError("Permission denied")
 
-        result = await remove_server("s", _make_ctx(), client="claude_code")
+        result = await remove_server("s", _make_ctx(), clients="claude_code")
 
         assert result["success"] is False
         assert "Permission denied" in result["message"]
 
-    @patch("mcp_tap.tools.remove.resolve_config_path")
-    async def test_unexpected_error(self, mock_resolve):
-        mock_resolve.side_effect = RuntimeError("disk failure")
+    @patch("mcp_tap.tools.remove.resolve_config_locations")
+    async def test_unexpected_error(self, mock_locations):
+        mock_locations.side_effect = RuntimeError("disk failure")
         ctx = _make_ctx()
 
-        result = await remove_server("s", ctx, client="claude_code")
+        result = await remove_server("s", ctx, clients="claude_code")
 
         assert result["success"] is False
         assert "RuntimeError" in result["message"]
         ctx.error.assert_awaited_once()
 
     @patch("mcp_tap.tools.remove.remove_server_config")
-    @patch("mcp_tap.tools.remove.resolve_config_path")
-    async def test_result_includes_config_file(self, mock_resolve, mock_remove):
-        mock_resolve.return_value = _fake_location(path="/home/user/.config/claude.json")
+    @patch("mcp_tap.tools.remove.resolve_config_locations")
+    async def test_result_includes_config_file(self, mock_locations, mock_remove):
+        mock_locations.return_value = [_fake_location(path="/home/user/.config/claude.json")]
         mock_remove.return_value = {"command": "npx"}
 
-        result = await remove_server("x", _make_ctx(), client="claude_code")
+        result = await remove_server("x", _make_ctx(), clients="claude_code")
 
         assert result["config_file"] == "/home/user/.config/claude.json"
 
     @patch("mcp_tap.tools.remove.remove_server_config")
-    @patch("mcp_tap.tools.remove.resolve_config_path")
-    async def test_message_mentions_restart(self, mock_resolve, mock_remove):
-        mock_resolve.return_value = _fake_location()
+    @patch("mcp_tap.tools.remove.resolve_config_locations")
+    async def test_message_mentions_restart(self, mock_locations, mock_remove):
+        mock_locations.return_value = [_fake_location()]
         mock_remove.return_value = {"command": "npx"}
 
-        result = await remove_server("x", _make_ctx(), client="claude_code")
+        result = await remove_server("x", _make_ctx(), clients="claude_code")
 
         assert "restart" in result["message"].lower()
+
+    @patch("mcp_tap.tools.remove.remove_server_config")
+    @patch("mcp_tap.tools.remove.resolve_config_locations")
+    async def test_scope_and_project_path_passed(self, mock_locations, mock_remove):
+        mock_locations.return_value = [
+            _fake_location(MCPClient.CURSOR, "/project/.cursor/mcp.json", scope="project")
+        ]
+        mock_remove.return_value = {"command": "npx"}
+
+        await remove_server(
+            "s", _make_ctx(), clients="cursor", scope="project", project_path="/project"
+        )
+
+        mock_locations.assert_called_once_with("cursor", scope="project", project_path="/project")
+
+
+# --- Multi-client tests ---------------------------------------------------
+
+
+class TestRemoveServerMulti:
+    @patch("mcp_tap.tools.remove.remove_server_config")
+    @patch("mcp_tap.tools.remove.resolve_config_locations")
+    async def test_multi_client_all_removed(self, mock_locations, mock_remove):
+        mock_locations.return_value = [
+            _fake_location(MCPClient.CLAUDE_DESKTOP, "/a"),
+            _fake_location(MCPClient.CURSOR, "/b"),
+        ]
+        mock_remove.return_value = {"command": "npx"}
+
+        result = await remove_server("s", _make_ctx(), clients="claude_desktop,cursor")
+
+        assert result["success"] is True
+        assert "per_client_results" in result
+        assert len(result["per_client_results"]) == 2
+        assert result["per_client_results"][0]["removed"] is True
+        assert result["per_client_results"][1]["removed"] is True
+        assert "2/2" in result["message"]
+
+    @patch("mcp_tap.tools.remove.remove_server_config")
+    @patch("mcp_tap.tools.remove.resolve_config_locations")
+    async def test_multi_client_not_found_in_one(self, mock_locations, mock_remove):
+        mock_locations.return_value = [
+            _fake_location(MCPClient.CLAUDE_DESKTOP, "/a"),
+            _fake_location(MCPClient.CURSOR, "/b"),
+        ]
+        # Found in first, not in second
+        mock_remove.side_effect = [{"command": "npx"}, None]
+
+        result = await remove_server("s", _make_ctx(), clients="claude_desktop,cursor")
+
+        assert result["success"] is True
+        assert "1/2" in result["message"]
+        per_client = result["per_client_results"]
+        assert per_client[0]["removed"] is True
+        assert per_client[1]["removed"] is False
+
+    @patch("mcp_tap.tools.remove.remove_server_config")
+    @patch("mcp_tap.tools.remove.resolve_config_locations")
+    async def test_multi_client_none_found(self, mock_locations, mock_remove):
+        mock_locations.return_value = [
+            _fake_location(MCPClient.CLAUDE_DESKTOP, "/a"),
+            _fake_location(MCPClient.CURSOR, "/b"),
+        ]
+        mock_remove.return_value = None
+
+        result = await remove_server("s", _make_ctx(), clients="claude_desktop,cursor")
+
+        assert result["success"] is False
+        assert "not found in any" in result["message"].lower()
+
+    @patch("mcp_tap.tools.remove.remove_server_config")
+    @patch("mcp_tap.tools.remove.resolve_config_locations")
+    async def test_multi_client_write_error_in_one(self, mock_locations, mock_remove):
+        mock_locations.return_value = [
+            _fake_location(MCPClient.CLAUDE_DESKTOP, "/a"),
+            _fake_location(MCPClient.CURSOR, "/b"),
+        ]
+        mock_remove.side_effect = [{"command": "npx"}, ConfigWriteError("Permission denied")]
+
+        result = await remove_server("s", _make_ctx(), clients="all")
+
+        assert result["success"] is True
+        per_client = result["per_client_results"]
+        assert per_client[0]["removed"] is True
+        assert per_client[1]["success"] is False


### PR DESCRIPTION
## Summary
- `configure_server` and `remove_server` now accept `clients` param ("all", comma-separated, or auto-detect) + `scope`/`project_path` for project-scoped configs
- Project-scoped paths: `.mcp.json` (Claude Code), `.cursor/mcp.json`, `.windsurf/mcp_config.json`
- New `resolve_config_locations()` unifies single/multi/all client resolution
- 18 new tests covering multi-client flows and project-scoped configs

Total: **320 tests** passing, ruff clean.

## Test plan
- [x] `pytest tests/` — 320 passed in 0.54s
- [x] `ruff check src/ tests/` — all checks passed
- [x] `ruff format --check src/ tests/` — 48 files already formatted
- [ ] GitHub Actions CI green on merge