### PR TITLE
Add PyPI publish workflow (trusted publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install Python 3.13
+        run: uv python install 3.13
+
+      - name: Build
+        run: uv build
+
+      - name: Smoke test (wheel)
+        run: uv run --isolated --no-project --with dist/*.whl tests/smoke_test.py
+
+      - name: Smoke test (source distribution)
+        run: uv run --isolated --no-project --with dist/*.tar.gz tests/smoke_test.py
+
+      - name: Publish
+        run: uv publish

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -1,0 +1,8 @@
+"""Smoke test to verify the built package works."""
+
+from mcp_tap import __version__, main
+
+assert __version__ == "0.1.0", f"Expected 0.1.0, got {__version__}"
+assert callable(main), "main() entry point must be callable"
+
+print(f"mcp-tap {__version__} smoke test passed")


### PR DESCRIPTION
## Summary
- GitHub Actions workflow that publishes to PyPI on version tags (`v*`)
- Uses trusted publishing (no API tokens stored in repo)
- Smoke tests wheel and sdist before publishing
- Requires `pypi` environment to be created in GitHub repo settings

## Setup required (one-time)
1. Create a `pypi` environment in GitHub repo Settings → Environments
2. Add trusted publisher on PyPI: https://pypi.org/manage/account/publishing/
   - Owner: `felipestenzel`
   - Repository: `mcp-tap`
   - Workflow: `publish.yml`
   - Environment: `pypi`

## To publish
```bash
git tag -a v0.1.0 -m v0.1.0
git push --tags
```

## Test plan
- [x] 320 tests passing
- [x] Ruff clean
- [ ] CI passes on this PR
- [ ] After merge: create pypi environment, add trusted publisher, tag v0.1.0