### PR TITLE
Add v0.2 roadmap issues (#10-#13)

### DIFF
--- a/docs/issues/2026-02-19_candidate-evaluation.md
+++ b/docs/issues/2026-02-19_candidate-evaluation.md
@@ -1,0 +1,204 @@
+# Candidate Evaluation — Compare Server Alternatives by Maturity
+
+- **Date**: 2026-02-19
+- **Status**: `open`
+- **Branch**: `feature/YYYY-MM-DD-candidate-evaluation`
+- **Priority**: `medium`
+- **Issue**: #13
+
+## Problem
+
+`search_servers` returns results from the MCP Registry ranked by keyword relevance and project stack match. But when multiple servers serve the same need (e.g., 4 PostgreSQL MCP servers), the user has no data to choose between them. They must leave the conversation, visit each GitHub repo, and manually compare stars, last update, maintenance status, and feature set.
+
+The original issue (adenhq/hive#4527) describes this in the `evaluate_candidates` node:
+
+> "When two candidate servers provide overlapping functionality, evaluate maturity (GitHub stars, last update, open issues) and recommend the one that better fits your architecture."
+
+> "I also looked at @alternative/pg-tools but it hasn't been updated in 5 months. Skipping."
+
+That single line — showing the agent REJECTING a candidate with reasoning — is what builds user trust.
+
+## Context
+
+- **Module affected**: `tools/search.py`, `registry/client.py`, new `evaluation/` module
+- **Existing infrastructure**:
+  - `SearchResult` already has `repository_url`, `updated_at`, `is_official`
+  - `RegistryServer` already has `version`, `packages` (with transport and env vars)
+  - `search_servers` already accepts `project_path` for relevance scoring
+  - `scanner/scoring.py` already has `score_result()` for project relevance
+- **Data sources available**:
+  - MCP Registry API: `updated_at`, `version`, `is_official` (already fetched)
+  - GitHub API: stars, forks, open issues, last commit date (NOT currently fetched)
+  - npm/PyPI: weekly downloads (NOT currently fetched)
+
+## Architecture
+
+### New module: `src/mcp_tap/evaluation/`
+
+```
+src/mcp_tap/evaluation/
+├── __init__.py
+├── github.py       # Fetch repo metadata from GitHub API
+└── scorer.py       # Compute maturity score from multiple signals
+```
+
+### Maturity signals and scoring
+
+```python
+@dataclass(frozen=True, slots=True)
+class MaturitySignals:
+    """Raw signals collected about a server's maturity/health."""
+    stars: int | None = None
+    forks: int | None = None
+    open_issues: int | None = None
+    last_commit_date: str | None = None      # ISO 8601
+    last_release_date: str | None = None     # ISO 8601
+    is_official: bool = False                 # From MCP Registry
+    is_archived: bool = False                 # From GitHub API
+    license: str | None = None
+    weekly_downloads: int | None = None       # From npm/PyPI (stretch)
+
+@dataclass(frozen=True, slots=True)
+class MaturityScore:
+    """Computed maturity assessment for a server."""
+    score: float               # 0.0-1.0 composite score
+    tier: str                  # "recommended", "acceptable", "caution", "avoid"
+    reasons: list[str]         # Human-readable reasons for the score
+    warning: str | None        # Warning if there's a red flag (archived, stale, etc.)
+```
+
+Scoring formula:
+- **is_official**: +0.3 (official MCP servers are curated)
+- **stars**: +0.0-0.2 (log scale: 0→0, 100→0.1, 1000→0.15, 5000+→0.2)
+- **last_commit_date**: +0.0-0.3 (within 30 days→0.3, 90 days→0.2, 180 days→0.1, older→0)
+- **is_archived**: -0.5 (archived repos should be flagged)
+- **open_issues > 50**: -0.1 (potential maintenance burden)
+
+Tier thresholds:
+- **recommended**: score ≥ 0.6
+- **acceptable**: score ≥ 0.4
+- **caution**: score ≥ 0.2
+- **avoid**: score < 0.2
+
+### GitHub API integration (`github.py`)
+
+```python
+async def fetch_repo_metadata(
+    repository_url: str,
+    http_client: httpx.AsyncClient,
+) -> MaturitySignals | None:
+    """Fetch repository metadata from GitHub's public API.
+
+    Uses unauthenticated requests (60 req/hour limit).
+    Returns None if the URL is not a GitHub repo or the API fails.
+
+    Converts: https://github.com/owner/repo → GET /repos/owner/repo
+    """
+```
+
+Rate limiting considerations:
+- GitHub public API: 60 requests/hour without auth
+- A typical `search_servers` call returns 5-10 results → 5-10 API calls
+- Cache results for the session (in-memory, not persisted)
+- Graceful degradation: if rate-limited, return results without maturity data
+
+### Integration into `search_servers`
+
+Add optional `evaluate: bool = True` parameter:
+
+```python
+async def search_servers(
+    query: str,
+    ctx: Context,
+    limit: int = 10,
+    project_path: str | None = None,
+    evaluate: bool = True,          # NEW
+) -> list[dict[str, object]]:
+```
+
+When `evaluate=True`:
+1. Run normal search
+2. For each result with a `repository_url`, fetch maturity signals
+3. Compute maturity scores
+4. Add `maturity` field to each result:
+
+```python
+{
+    "name": "@modelcontextprotocol/server-postgres",
+    "description": "...",
+    "relevance": "high",
+    "maturity": {                          # NEW
+        "score": 0.85,
+        "tier": "recommended",
+        "stars": 2300,
+        "last_commit": "3 days ago",
+        "reasons": [
+            "Official MCP server",
+            "2.3k stars",
+            "Active development (last commit 3 days ago)"
+        ],
+    },
+}
+```
+
+5. Sort results by: relevance (primary) → maturity score (secondary)
+
+When `evaluate=False`: skip GitHub API calls (faster, no rate limit risk).
+
+### Comparison output
+
+When multiple servers match the same need, the tool should output a comparison:
+
+```python
+{
+    "comparison": {
+        "category": "postgresql",
+        "recommended": "@modelcontextprotocol/server-postgres",
+        "alternatives": [
+            {
+                "name": "@alternative/pg-tools",
+                "maturity": {"tier": "caution", "score": 0.25},
+                "reason_not_recommended": "Last updated 5 months ago, 3 open issues with no response"
+            }
+        ]
+    }
+}
+```
+
+## Scope
+
+1. `src/mcp_tap/models.py` — Add `MaturitySignals`, `MaturityScore` dataclasses
+2. `src/mcp_tap/evaluation/__init__.py` — NEW
+3. `src/mcp_tap/evaluation/github.py` — NEW: GitHub API metadata fetcher
+4. `src/mcp_tap/evaluation/scorer.py` — NEW: maturity scoring logic
+5. `src/mcp_tap/tools/search.py` — Add `evaluate` param, integrate maturity scoring
+6. `tests/test_evaluation.py` — NEW: tests for GitHub fetcher and scorer
+
+## Test Plan
+
+- [ ] GitHub URL → API path conversion correct (handles various URL formats)
+- [ ] MaturitySignals populated from mocked GitHub API response
+- [ ] Scoring: official server with recent commits scores ≥ 0.6
+- [ ] Scoring: archived repo scores < 0.2
+- [ ] Scoring: stale repo (6+ months) gets "caution" tier
+- [ ] search_servers with evaluate=True includes maturity in results
+- [ ] search_servers with evaluate=False skips maturity (faster)
+- [ ] Rate limit handling: graceful degradation when GitHub API returns 429
+- [ ] All httpx calls are mocked (tests run offline)
+- [ ] All 320+ existing tests still pass
+
+## Root Cause
+
+`search_servers` returns results without maturity context. The user cannot distinguish between a well-maintained official server and an abandoned fork without leaving the conversation.
+
+## Solution
+
+(Fill after implementation)
+
+## Files Changed
+
+(Fill after implementation)
+
+## Lessons Learned
+
+(Fill after implementation)

--- a/docs/issues/2026-02-19_credential-detection.md
+++ b/docs/issues/2026-02-19_credential-detection.md
@@ -1,0 +1,184 @@
+# Credential Detection and Mapping
+
+- **Date**: 2026-02-19
+- **Status**: `open`
+- **Branch**: `feature/YYYY-MM-DD-credential-detection`
+- **Priority**: `high`
+- **Issue**: #11
+
+## Problem
+
+When `configure_server` is called, the user must manually know which environment variables a server needs AND what values to pass. Even when the project already has the credentials in `.env` or `docker-compose.yml` under a slightly different name, mcp-tap doesn't detect or reuse them.
+
+Today's behavior:
+```
+LLM: "What's your POSTGRES_CONNECTION_STRING?"
+User: "I don't know... I think I have DATABASE_URL in my .env?"
+LLM: "Let me check... ok pass env_vars='POSTGRES_CONNECTION_STRING=...'"
+```
+
+Target behavior:
+```
+scan_project result:
+  env_vars_found: ["DATABASE_URL", "SLACK_BOT_TOKEN", "GITHUB_TOKEN"]
+  credential_mapping:
+    - server: postgres-mcp
+      required: POSTGRES_CONNECTION_STRING
+      available_as: DATABASE_URL (from .env)
+      status: "available — will reuse DATABASE_URL"
+    - server: slack-mcp
+      required: SLACK_BOT_TOKEN
+      available_as: SLACK_BOT_TOKEN (from .env)
+      status: "available — exact match"
+    - server: github-mcp
+      required: GITHUB_TOKEN
+      available_as: null
+      status: "missing — create at https://github.com/settings/tokens"
+```
+
+This directly addresses the original issue's Phase 2 (Credential Intelligence) and its insight that the agent should "detect existing credentials, collect missing ones securely."
+
+## Context
+
+- **Module affected**: `scanner/detector.py` (already reads `.env` names), `scanner/recommendations.py` (already maps tech→server), `tools/scan.py`, `tools/configure.py`
+- **Existing infrastructure**:
+  - `detector.py:_parse_env_files()` already extracts env var NAMES from `.env`, `.env.example`, `.env.local`
+  - `detector.py:_ENV_PATTERNS` already maps env var patterns → technologies (e.g., `POSTGRES*` → postgresql)
+  - `SearchResult.env_vars_required` already lists required env vars per server from the Registry API
+  - `ServerRecommendation` already has `server_name` and `package_identifier`
+  - `configure_server` already accepts `env_vars` as comma-separated KEY=VALUE
+- **What's missing**: The bridge between "project has DATABASE_URL" and "postgres-mcp needs POSTGRES_CONNECTION_STRING" — the **mapping logic**.
+
+## Architecture
+
+### New model: `CredentialMapping`
+
+```python
+@dataclass(frozen=True, slots=True)
+class CredentialMapping:
+    """Maps a server's required env var to an available project credential."""
+    server_name: str
+    required_env_var: str           # What the MCP server expects (e.g. POSTGRES_CONNECTION_STRING)
+    available_env_var: str | None   # What the project has (e.g. DATABASE_URL), or None
+    source: str                     # Where found: ".env", "docker-compose.yml", "not found"
+    status: str                     # "exact_match", "compatible_match", "missing"
+    help_url: str                   # Where to create the credential (e.g. GitHub tokens page)
+```
+
+### New module: `src/mcp_tap/scanner/credentials.py`
+
+Responsible for:
+1. Taking a `ProjectProfile` (with `env_var_names`) and a list of `ServerRecommendation`
+2. Looking up each recommendation's required env vars (from Registry API data or static mapping)
+3. Matching required vars against available vars using:
+   - **Exact match**: `SLACK_BOT_TOKEN` required, `SLACK_BOT_TOKEN` found in `.env`
+   - **Compatible match**: `POSTGRES_CONNECTION_STRING` required, `DATABASE_URL` found — same type of credential
+   - **Missing**: No match found
+4. Returning a list of `CredentialMapping` for each recommendation
+
+### Compatibility mapping table
+
+Static knowledge about which env var names are interchangeable:
+
+```python
+COMPATIBLE_VARS: dict[str, list[str]] = {
+    # Required var → list of compatible alternatives
+    "POSTGRES_CONNECTION_STRING": ["DATABASE_URL", "POSTGRES_URL", "PG_URL", "PG_CONNECTION_STRING"],
+    "GITHUB_TOKEN": ["GH_TOKEN", "GITHUB_PERSONAL_ACCESS_TOKEN"],
+    "SLACK_BOT_TOKEN": ["SLACK_TOKEN", "SLACK_API_TOKEN"],
+    "REDIS_URL": ["REDIS_CONNECTION_STRING", "REDIS_HOST"],
+    "MONGODB_URI": ["MONGO_URL", "MONGODB_URL", "MONGO_URI"],
+    "MYSQL_CONNECTION_STRING": ["MYSQL_URL", "DATABASE_URL"],
+}
+```
+
+### Help URL mapping
+
+Static mapping from env var patterns to creation help pages:
+
+```python
+CREDENTIAL_HELP: dict[str, str] = {
+    "GITHUB_TOKEN": "https://github.com/settings/tokens/new",
+    "SLACK_BOT_TOKEN": "https://api.slack.com/apps",
+    "OPENAI_API_KEY": "https://platform.openai.com/api-keys",
+    "ANTHROPIC_API_KEY": "https://console.anthropic.com/settings/keys",
+}
+```
+
+### Integration into `scan_project`
+
+After `recommend_servers()`, call `map_credentials()` to produce credential mappings. Include them in the scan result:
+
+```python
+# In tools/scan.py
+return {
+    "path": profile.path,
+    "detected_technologies": technologies,
+    "env_vars_found": profile.env_var_names,
+    "recommendations": recommendations,
+    "credential_mappings": credential_mappings,   # NEW
+    "already_installed": already_installed,
+    "summary": summary,
+}
+```
+
+### Integration into `configure_server`
+
+When `env_vars` is empty, auto-populate from credential mappings:
+- If `scan_project` detected `DATABASE_URL` and the server needs `POSTGRES_CONNECTION_STRING`, and both are available in the environment → auto-map
+- The tool should NOT read credential VALUES — only report the mapping to the LLM, which asks the user
+
+### Integration into `search_servers`
+
+Enrich search results with credential availability when `project_path` is provided:
+
+```python
+# Each result gets:
+{
+    "name": "postgres-mcp",
+    "env_vars_required": ["POSTGRES_CONNECTION_STRING"],
+    "credential_status": "available",       # NEW: available/partial/missing
+    "credential_details": [                 # NEW
+        {
+            "required": "POSTGRES_CONNECTION_STRING",
+            "available_as": "DATABASE_URL",
+            "source": ".env"
+        }
+    ]
+}
+```
+
+## Scope
+
+1. `src/mcp_tap/models.py` — Add `CredentialMapping` dataclass
+2. `src/mcp_tap/scanner/credentials.py` — NEW: credential mapping logic
+3. `src/mcp_tap/scanner/recommendations.py` — Add required env vars to `ServerRecommendation`
+4. `src/mcp_tap/tools/scan.py` — Include credential mappings in output
+5. `src/mcp_tap/tools/search.py` — Enrich results with credential status
+6. `tests/test_credentials.py` — NEW: tests for credential mapping
+
+## Test Plan
+
+- [ ] Exact match: `SLACK_BOT_TOKEN` found when `SLACK_BOT_TOKEN` required → status `exact_match`
+- [ ] Compatible match: `DATABASE_URL` found when `POSTGRES_CONNECTION_STRING` required → status `compatible_match`
+- [ ] Missing: no match for `GITHUB_TOKEN` → status `missing`, help_url populated
+- [ ] scan_project includes credential_mappings in output
+- [ ] search_servers includes credential_status when project_path provided
+- [ ] No credential VALUES are ever read or returned (only names)
+- [ ] All 320+ existing tests still pass
+
+## Root Cause
+
+`scan_project` and `search_servers` operate in isolation — scan detects env vars, search lists required vars, but nothing connects the two.
+
+## Solution
+
+(Fill after implementation)
+
+## Files Changed
+
+(Fill after implementation)
+
+## Lessons Learned
+
+(Fill after implementation)

--- a/docs/issues/2026-02-19_doc-comprehension.md
+++ b/docs/issues/2026-02-19_doc-comprehension.md
@@ -1,0 +1,186 @@
+# Documentation Comprehension — Extract Config from Server READMEs
+
+- **Date**: 2026-02-19
+- **Status**: `open`
+- **Branch**: `feature/YYYY-MM-DD-doc-comprehension`
+- **Priority**: `medium`
+- **Issue**: #12
+
+## Problem
+
+`configure_server` depends on the MCP Registry API for structured data (transport, command, args, env vars). When a server is NOT in the registry, or the registry data is incomplete (missing env vars, wrong transport), the tool fails or produces broken configs.
+
+The original issue (adenhq/hive#4527) identifies this as the core "interpretation gap":
+
+> "A CLI tool can run `npm install`. It cannot read an arbitrary README, understand that 'set the GITHUB_TOKEN environment variable with repo scope' means it needs to create a credential entry, infer the transport type from installation instructions, and generate a correct configuration."
+
+Today mcp-tap cannot bridge this gap. It relies entirely on pre-structured registry data.
+
+### Examples of what breaks today
+
+1. **Server not in registry**: User finds `mcp-server-kubernetes` on GitHub. It's not in the MCP Registry. `search_servers` returns nothing. The user must manually figure out command, args, env vars, and transport.
+
+2. **Incomplete registry data**: Registry says a server needs `API_KEY` but the README says it actually needs `API_KEY` AND `API_SECRET` AND `WEBHOOK_URL`. Config is written with only `API_KEY`, validation fails.
+
+3. **Ambiguous transport**: Registry says `stdio` but the server actually supports `streamable-http` on port 3000 and `stdio` only works with specific args. Config is wrong.
+
+## Context
+
+- **Key insight**: mcp-tap runs inside an LLM. The LLM CAN read documentation. What mcp-tap needs is a tool that **fetches** a server's README and returns structured data the LLM can act on.
+- **Module affected**: New tool + new module
+- **Existing infrastructure**:
+  - `SearchResult.repository_url` already has the GitHub URL of each server
+  - `configure_server` already accepts all config params (command, args, env_vars, registry_type)
+  - The LLM can already reason about documentation — we just need to fetch and pre-process it
+
+## Architecture
+
+### New tool: `inspect_server`
+
+A new MCP tool that fetches a server's documentation and extracts structured configuration hints. This is a **read-only** tool — it doesn't install or configure anything.
+
+```python
+async def inspect_server(
+    repository_url: str,
+    ctx: Context,
+) -> dict[str, object]:
+    """Fetch an MCP server's documentation and extract configuration details.
+
+    Use this when search_servers returns incomplete data (missing env vars,
+    unclear transport) or when you have a GitHub URL for a server not in the
+    registry.
+
+    Fetches the README.md from the repository URL and extracts:
+    - Install commands (npm, pip, docker)
+    - Transport type (stdio, http, sse)
+    - Required environment variables with descriptions
+    - Command and args patterns
+    - Usage examples
+
+    The extracted data may be incomplete or ambiguous — use your judgment
+    to fill gaps based on the raw README content also returned.
+
+    Args:
+        repository_url: GitHub/GitLab repository URL
+            (e.g. "https://github.com/modelcontextprotocol/servers").
+
+    Returns:
+        Dict with: extracted_config (structured hints), raw_readme
+        (first 5000 chars of README for LLM reasoning), and
+        confidence (how much structured data was found).
+    """
+```
+
+### New module: `src/mcp_tap/inspector/`
+
+```
+src/mcp_tap/inspector/
+├── __init__.py
+├── fetcher.py      # Fetch README from GitHub/GitLab URLs
+└── extractor.py    # Regex-based extraction of config hints from README text
+```
+
+#### `fetcher.py` — README retrieval
+
+```python
+async def fetch_readme(repository_url: str, http_client: httpx.AsyncClient) -> str | None:
+    """Fetch README.md from a repository URL.
+
+    Supports:
+    - GitHub: converts to raw.githubusercontent.com URL
+    - GitLab: converts to raw API URL
+    - Direct URLs: fetches as-is
+
+    Returns the raw markdown text, or None if not found.
+    """
+```
+
+URL conversion logic:
+- `https://github.com/owner/repo` → `https://raw.githubusercontent.com/owner/repo/HEAD/README.md`
+- `https://github.com/owner/repo/tree/main/packages/server-foo` → `https://raw.githubusercontent.com/owner/repo/main/packages/server-foo/README.md`
+- `https://gitlab.com/owner/repo` → `https://gitlab.com/owner/repo/-/raw/main/README.md`
+
+#### `extractor.py` — Pattern-based extraction
+
+Extract structured hints from README markdown using regex patterns. NOT an LLM call — deterministic extraction that provides hints for the LLM to reason about.
+
+```python
+@dataclass(frozen=True, slots=True)
+class ConfigHints:
+    """Structured hints extracted from a server's documentation."""
+    install_commands: list[str]           # e.g. ["npx -y @foo/bar", "pip install foo"]
+    transport_hints: list[str]            # e.g. ["stdio", "http"]
+    env_vars_mentioned: list[EnvVarHint]  # env var names + surrounding context
+    command_patterns: list[str]           # e.g. ["npx -y @foo/bar --port 3000"]
+    json_config_blocks: list[str]         # any JSON blocks that look like MCP config
+    confidence: float                      # 0.0-1.0 based on how many patterns matched
+
+@dataclass(frozen=True, slots=True)
+class EnvVarHint:
+    name: str
+    context: str       # The sentence/line where this var was mentioned
+    is_required: bool  # True if context suggests it's required (not optional)
+```
+
+Extraction patterns:
+1. **Install commands**: Match `npm install`, `npx`, `pip install`, `uvx`, `docker run` in code blocks
+2. **Env vars**: Match `[A-Z][A-Z0-9_]+` in code blocks, especially after `env:`, `environment:`, or in `.env` examples
+3. **Transport hints**: Match `stdio`, `http`, `sse`, `streamable-http` in text or config blocks
+4. **JSON config blocks**: Match JSON blocks containing `"command"`, `"args"`, `"env"` keys
+5. **Command patterns**: Match shell commands in code blocks that look like server invocations
+
+### Integration
+
+1. Register `inspect_server` in `server.py` as a read-only tool
+2. The LLM workflow becomes:
+   - `search_servers("kubernetes")` → finds server but env vars incomplete
+   - `inspect_server(repository_url)` → gets README + extracted hints
+   - LLM reasons about hints + raw README
+   - `configure_server(...)` with correct params
+
+### What this does NOT do
+
+- Does NOT call an LLM to parse the README (that's the host LLM's job)
+- Does NOT auto-generate configs from docs (too risky without human review)
+- Does NOT replace the Registry API (registry data is preferred when available)
+- Does NOT cache READMEs (each fetch is fresh — READMEs change)
+
+## Scope
+
+1. `src/mcp_tap/models.py` — Add `ConfigHints`, `EnvVarHint` dataclasses
+2. `src/mcp_tap/inspector/__init__.py` — NEW
+3. `src/mcp_tap/inspector/fetcher.py` — NEW: README fetch from GitHub/GitLab
+4. `src/mcp_tap/inspector/extractor.py` — NEW: regex-based extraction
+5. `src/mcp_tap/tools/inspect.py` — NEW: `inspect_server` tool
+6. `src/mcp_tap/server.py` — Register `inspect_server` as read-only tool
+7. `tests/test_inspector.py` — NEW: tests for fetcher and extractor
+
+## Test Plan
+
+- [ ] fetcher converts GitHub URLs to raw.githubusercontent.com correctly
+- [ ] fetcher converts GitLab URLs correctly
+- [ ] fetcher handles monorepo paths (e.g. `github.com/org/repo/tree/main/packages/server-foo`)
+- [ ] fetcher returns None for 404s gracefully
+- [ ] extractor finds env vars in README code blocks
+- [ ] extractor finds install commands (npm, pip, docker)
+- [ ] extractor finds transport hints
+- [ ] extractor finds JSON config blocks
+- [ ] inspect_server returns structured hints + raw README
+- [ ] All httpx calls are mocked (tests run offline)
+- [ ] All 320+ existing tests still pass
+
+## Root Cause
+
+mcp-tap has no way to fetch or process server documentation. It's a blind spot between "find a server" and "configure it correctly."
+
+## Solution
+
+(Fill after implementation)
+
+## Files Changed
+
+(Fill after implementation)
+
+## Lessons Learned
+
+(Fill after implementation)

--- a/docs/issues/2026-02-19_self-healing.md
+++ b/docs/issues/2026-02-19_self-healing.md
@@ -1,65 +1,203 @@
-# Self-Healing Retry Loop (Post-Launch)
+# Self-Healing Retry Loop — Diagnose, Fix, Retry
 
 - **Date**: 2026-02-19
 - **Status**: `open`
 - **Branch**: `feature/YYYY-MM-DD-self-healing`
-- **Priority**: `low`
+- **Priority**: `critical`
 - **Issue**: #10
 
 ## Problem
 
-When a server installation or connection fails, mcp-tap just reports the error. It does not attempt to diagnose, fix, and retry. "My MCP server broke and mcp-tap fixed it" is the #2 differentiator from the creative brief.
+When `configure_server` installs a server and validation fails, or when `check_health` finds unhealthy servers, mcp-tap returns the raw error and stops. The user is left alone to debug — the exact pain point mcp-tap was built to eliminate.
+
+Today's behavior:
+```
+configure_server → install ✓ → write config ✓ → validate ✗
+→ "ConnectionRefused: port 5432" → user googles for 20 minutes
+```
+
+Target behavior:
+```
+configure_server → install ✓ → write config ✓ → validate ✗
+→ diagnose: "port 5432 refused — docker-compose uses 54320"
+→ fix config: port 5432 → 54320
+→ retry validate ✓ → "Connected. 8 tools available."
+```
+
+This is the #1 differentiator from the original issue (adenhq/hive#4527). Without it, mcp-tap is a "CLI tool that installs" rather than an "agent that makes things work."
 
 ## Context
 
-- **DEFERRED TO POST-LAUNCH** — the error taxonomy is unknowable until real users hit real failures
-- Building a classifier for imagined errors is waste; real user data will reveal actual failure modes
-- Prerequisite: Issue #3 (E2E install flow) and Issue #4 (health check) must work first
-- Launch, collect 50+ error reports, THEN build self-healing against real patterns
+- **Module affected**: `connection/tester.py` (already returns structured errors), `tools/configure.py` (calls `_validate`), `tools/health.py` (batch check)
+- **Existing infrastructure**: `ConnectionTestResult` already captures error type and message. `tester.py` already distinguishes `TimeoutError`, `FileNotFoundError`, and generic exceptions.
+- **The original issue** describes a `diagnose_fix` node with `max_node_visits: 3` — a feedback loop that reads errors, reasons about causes, applies fixes, and retries.
 
-## Scope (Planned — Refine After Launch Data)
+## Architecture
 
-1. **New module** (`healing/`):
-   - `classifier.py` — parse error messages into categories:
-     - ENOENT (command not found)
-     - CONNECTION_REFUSED (wrong port, transport mismatch)
-     - AUTH_FAILED (missing/invalid credentials)
-     - TIMEOUT (server too slow to start)
-     - MISSING_ENV_VAR (required env var not set)
-   - `fixer.py` — for each category, generate a candidate fix:
-     - ENOENT → suggest install command
-     - CONNECTION_REFUSED → try alternate transport
-     - AUTH_FAILED → prompt for credentials
-     - MISSING_ENV_VAR → suggest env var name and format
+### New module: `src/mcp_tap/healing/`
 
-2. **Retry wrapper**:
-   - Apply fix → re-test → up to 3 attempts
-   - Each attempt logged with what was tried
+```
+src/mcp_tap/healing/
+├── __init__.py
+├── classifier.py    # Error → ErrorCategory classification
+├── fixer.py         # ErrorCategory → CandidateFix generation
+└── retry.py         # Fix → rewrite config → re-validate → loop
+```
 
-3. **Integration**:
-   - Post-validation step in `configure_server`
-   - Optional auto-heal in `test_connection`
-   - Triggered by `check_health` for batch fixes
+### Error Classification (`classifier.py`)
+
+Parse error messages from `ConnectionTestResult.error` into structured categories:
+
+```python
+class ErrorCategory(StrEnum):
+    COMMAND_NOT_FOUND = "command_not_found"      # FileNotFoundError, ENOENT
+    CONNECTION_REFUSED = "connection_refused"      # wrong port, server not running
+    TIMEOUT = "timeout"                           # server too slow to start
+    AUTH_FAILED = "auth_failed"                   # missing/invalid credentials
+    MISSING_ENV_VAR = "missing_env_var"           # required env var not set
+    TRANSPORT_MISMATCH = "transport_mismatch"     # stdio vs http confusion
+    PERMISSION_DENIED = "permission_denied"       # file/network permissions
+    UNKNOWN = "unknown"                           # unclassifiable
+
+@dataclass(frozen=True, slots=True)
+class DiagnosisResult:
+    category: ErrorCategory
+    original_error: str
+    explanation: str        # Human-readable explanation for LLM consumption
+    suggested_fix: str      # What the fixer should try
+    confidence: float       # 0.0-1.0 how sure we are about the diagnosis
+```
+
+Classification rules (pattern matching on error strings):
+- `"Command not found"` / `"FileNotFoundError"` / `"ENOENT"` → `COMMAND_NOT_FOUND`
+- `"Connection refused"` / `"ECONNREFUSED"` → `CONNECTION_REFUSED`
+- `"did not respond within"` / `"TimeoutError"` → `TIMEOUT`
+- `"401"` / `"403"` / `"authentication"` / `"unauthorized"` → `AUTH_FAILED`
+- `"not set"` / `"missing"` / `"required"` + env var pattern → `MISSING_ENV_VAR`
+- `"Permission denied"` / `"EACCES"` → `PERMISSION_DENIED`
+
+### Fix Generation (`fixer.py`)
+
+For each `ErrorCategory`, generate a `CandidateFix`:
+
+```python
+@dataclass(frozen=True, slots=True)
+class CandidateFix:
+    description: str                    # What we're trying
+    new_config: ServerConfig | None     # Modified config, or None if not a config fix
+    install_command: str | None         # Re-install command, or None
+    env_var_hint: str | None            # Env var guidance for the user
+    requires_user_action: bool          # True if we can't fix this automatically
+```
+
+Fix strategies per category:
+
+| Category | Auto-fix | Strategy |
+|----------|----------|----------|
+| `COMMAND_NOT_FOUND` | Yes | Try alternative runner: `npx` → global path lookup → `uvx` → `pip` installed path |
+| `CONNECTION_REFUSED` | Partial | Check if Docker is running, suggest port from docker-compose.yml if available |
+| `TIMEOUT` | Yes | Increase timeout to 30s, then 60s. If still fails, check if deps are missing |
+| `AUTH_FAILED` | No | Report which env var is likely wrong/missing, provide help URL |
+| `MISSING_ENV_VAR` | No | Identify which vars are needed (from registry data), check if user's .env has them under different names |
+| `TRANSPORT_MISMATCH` | Yes | Flip stdio↔http in the config, retry |
+| `PERMISSION_DENIED` | Partial | Suggest `--prefix ~/.local` for npm, check file permissions |
+| `UNKNOWN` | No | Return the raw error with context for the LLM to reason about |
+
+### Retry Loop (`retry.py`)
+
+```python
+async def heal_and_retry(
+    server_name: str,
+    server_config: ServerConfig,
+    error: ConnectionTestResult,
+    *,
+    max_attempts: int = 3,
+    project_path: str | None = None,
+) -> HealingResult:
+    """Diagnose an error, apply a fix, and retry validation.
+
+    Loops up to max_attempts times. Each iteration:
+    1. Classify the error
+    2. Generate a candidate fix
+    3. If auto-fixable: apply fix, re-validate
+    4. If not auto-fixable: return diagnosis with user guidance
+
+    Returns HealingResult with: fixed (bool), attempts made,
+    final config (if modified), and user_action_needed (str) if
+    the fix requires human intervention.
+    """
+```
+
+```python
+@dataclass(frozen=True, slots=True)
+class HealingResult:
+    fixed: bool
+    attempts: list[HealingAttempt]
+    final_config: ServerConfig | None    # The working config, if fixed
+    user_action_needed: str              # Guidance if human must intervene
+
+@dataclass(frozen=True, slots=True)
+class HealingAttempt:
+    attempt_number: int
+    diagnosis: DiagnosisResult
+    fix_applied: CandidateFix
+    result: ConnectionTestResult         # Re-validation result
+```
+
+### Integration Points
+
+1. **`configure_server`** — After `_validate` fails, call `heal_and_retry`. If healed, update the written config with the fixed version. Return `HealingResult` alongside `ConfigureResult`.
+
+2. **`check_health`** — When servers are unhealthy, optionally trigger healing for each. Add `auto_heal: bool = False` parameter to `check_health`.
+
+3. **`test_connection`** — Add `auto_heal: bool = False` parameter. When True, attempt healing before returning failure.
+
+### New models in `models.py`
+
+```python
+class ErrorCategory(StrEnum): ...
+class DiagnosisResult: ...
+class CandidateFix: ...
+class HealingAttempt: ...
+class HealingResult: ...
+```
+
+## Scope
+
+1. `src/mcp_tap/healing/__init__.py`
+2. `src/mcp_tap/healing/classifier.py` — Error pattern matching → ErrorCategory
+3. `src/mcp_tap/healing/fixer.py` — ErrorCategory → CandidateFix
+4. `src/mcp_tap/healing/retry.py` — Orchestrate diagnose → fix → re-validate loop
+5. `src/mcp_tap/models.py` — Add ErrorCategory, DiagnosisResult, CandidateFix, HealingAttempt, HealingResult
+6. `src/mcp_tap/tools/configure.py` — Integrate healing after validation failure
+7. `src/mcp_tap/tools/health.py` — Add `auto_heal` parameter
+8. `src/mcp_tap/tools/test.py` — Add `auto_heal` parameter
+9. `tests/test_healing.py` — Unit tests for classifier, fixer, retry loop
+
+## Test Plan
+
+- [ ] Classifier correctly maps ≥6 error patterns to categories
+- [ ] Fixer generates valid CandidateFix for each auto-fixable category
+- [ ] Retry loop stops after max_attempts
+- [ ] Retry loop stops early when fix succeeds
+- [ ] `requires_user_action=True` fixes are NOT auto-applied
+- [ ] configure_server returns HealingResult when validation fails then heals
+- [ ] check_health with auto_heal=True triggers healing for unhealthy servers
+- [ ] All tests mock subprocess/connection (no real servers needed)
+- [ ] 100% of existing tests still pass
 
 ## Root Cause
 
-No error diagnosis logic exists — only basic error reporting.
+No error diagnosis logic exists — `ConnectionTestResult.error` is a raw string that gets passed through without interpretation.
 
 ## Solution
 
-(Fill after real user error data is collected)
+(Fill after implementation)
 
 ## Files Changed
 
 (Fill after implementation)
 
-## Verification
-
-- [ ] Tests pass with intentionally broken server configs
-- [ ] At least 3 error categories correctly classified
-- [ ] Retry loop fixes at least 2 common failure modes
-- [ ] Clear reporting of what was tried and what worked
-
 ## Lessons Learned
 
-**Strategic note**: Do NOT build this pre-launch. The first 50 real users will tell us exactly what breaks and how. That data is worth more than any amount of upfront engineering.
+(Fill after implementation)


### PR DESCRIPTION
## Summary
Four detailed issue documents for v0.2, closing the gap with the original Hive Toolsmith vision (adenhq/hive#4527):

- **#10 Self-Healing** (critical) — Diagnose errors, fix config, retry up to 3x. New `healing/` module with classifier, fixer, and retry loop.
- **#11 Credential Detection** (high) — Map project env vars to server requirements. Detect `DATABASE_URL` → `POSTGRES_CONNECTION_STRING` compatibility.
- **#12 Doc Comprehension** (medium) — New `inspect_server` tool that fetches READMEs and extracts config hints for servers not in the registry.
- **#13 Candidate Evaluation** (medium) — Compare alternatives by GitHub stars, last commit, maintenance status. "I skipped this one because it hasn't been updated in 5 months."

Docs-only change — no code modified.

## Test plan
- [x] All issue docs follow project template
- [x] Each issue specifies architecture, scope, test plan, and integration points