### PR TITLE
Add native_capabilities to scan output for LLM awareness

### DIFF
--- a/src/mcp_tap/tools/scan.py
+++ b/src/mcp_tap/tools/scan.py
@@ -13,6 +13,7 @@ from mcp_tap.errors import McpTapError
 from mcp_tap.models import MCPClient
 from mcp_tap.scanner.credentials import map_credentials
 from mcp_tap.scanner.detector import scan_project as _scan_project
+from mcp_tap.scanner.recommendations import CLIENT_NATIVE_CAPABILITIES
 
 
 async def scan_project(
@@ -91,8 +92,13 @@ async def scan_project(
             env_var_count=len(profile.env_var_names),
         )
 
+        # Build native capabilities list for the detected client
+        native_caps = _get_native_capabilities(resolved_client)
+
         return {
             "path": profile.path,
+            "client": resolved_client.value if resolved_client else "unknown",
+            "native_capabilities": native_caps,
             "detected_technologies": technologies,
             "env_vars_found": profile.env_var_names,
             "recommendations": recommendations,
@@ -106,6 +112,31 @@ async def scan_project(
     except Exception as exc:
         await ctx.error(f"Unexpected error in scan_project: {exc}")
         return {"success": False, "error": f"Internal error: {type(exc).__name__}"}
+
+
+def _get_native_capabilities(client: MCPClient | None) -> list[dict[str, str]]:
+    """Build a list of native capabilities for the detected client.
+
+    This is included in the scan output so the LLM sees it as DATA,
+    not just instructions. Each entry describes a capability the client
+    already has natively, so no MCP server is needed for it.
+    """
+    if not client:
+        return []
+    capabilities = CLIENT_NATIVE_CAPABILITIES.get(client, [])
+    return [
+        {
+            "capability": ", ".join(cap.keywords),
+            "native_tool": cap.reason,
+            "do_not_recommend": (
+                f"Do NOT recommend any MCP server related to "
+                f"{', '.join(cap.keywords)} — {cap.reason}. "
+                f"This applies to ALL packages matching these keywords, "
+                f"regardless of publisher or package name."
+            ),
+        }
+        for cap in capabilities
+    ]
 
 
 def _resolve_client(client: str | None) -> MCPClient | None:


### PR DESCRIPTION
## Problem
v0.2.2 correctly filters redundant servers from scan_project recommendations, but the LLM goes beyond scan results — it does web searches to find additional MCPs and still recommends GitHub MCP, git MCP, etc. despite instructions saying not to. Instructions alone aren't enough.

## Fix
Return `native_capabilities` as explicit DATA in scan_project output. Each entry includes:
- `capability`: what the client already does (e.g. "github")
- `native_tool`: how (e.g. "Claude Code has native Bash access to the gh CLI")
- `do_not_recommend`: explicit directive the LLM sees in the tool response

When the LLM sees this in the actual tool output (not just instructions), it's much harder to ignore.

## Example output for Claude Code
```json
"native_capabilities": [
  {
    "capability": "filesystem, file-system",
    "native_tool": "Claude Code has native Read/Write/Edit/Glob/Grep tools",
    "do_not_recommend": "Do NOT recommend any MCP server related to filesystem..."
  },
  {
    "capability": "github",
    "native_tool": "Claude Code has native Bash access to the gh CLI...",
    "do_not_recommend": "Do NOT recommend any MCP server related to github..."
  }
]
```