### PR TITLE
Fix 7 production bugs: H2-H4 + M1-M4

### DIFF
--- a/docs/issues/2026-02-19_premium-quality-roadmap.md
+++ b/docs/issues/2026-02-19_premium-quality-roadmap.md
@@ -52,23 +52,20 @@ Sem corrigir esses 4 problemas, o produto não é confiável para uso real.
 - **Fix aplicado**: `httpx.AsyncHTTPTransport(retries=3)` no `server.py` lifespan
 - **Testes**: 5 novos (transport retries, timeout config, follow_redirects, lifecycle)
 
-#### H2. Healing loop spawna até 7 processos por servidor
-- **Arquivo**: `src/mcp_tap/tools/configure.py` (linhas 147-205)
-- **Fix**: Reutilizar erro original em `_try_heal`, reduzir max_attempts de 3 para 2.
-- **Esforço**: S
+#### H2. Healing loop spawna até 7 processos por servidor ✅ DONE
+- **Branch**: `fix/2026-02-19-production-hardening-r2`
+- **Fix aplicado**: max_attempts 3→2, _try_heal forwards original error, removed redundant post-heal validation
+- **Testes**: +4 novos (max attempts default, error forwarding, no redundant validation)
 
-#### H3. configure_server não é transacional
-- **Arquivo**: `src/mcp_tap/tools/configure.py`
-- **Problema**: Config é escrito mesmo se validação falha. `success=True` com
-  `validation_passed=False` é enganoso.
-- **Fix**: Status mais granular ou rollback da config entry se validação falha.
-- **Esforço**: M
+#### H3. configure_server não é transacional ✅ DONE
+- **Branch**: `fix/2026-02-19-production-hardening-r2`
+- **Fix aplicado**: write_server_config moved to AFTER validation, success=False if validation fails
+- **Testes**: +3 novos (config written on success, not written on failure, multi-client failure)
 
-#### H4. Connection tester — cleanup incerto no timeout
-- **Arquivo**: `src/mcp_tap/connection/tester.py` (linhas 23-63)
-- **Problema**: Se o shutdown do `stdio_client` travar, processo pode ficar pendurado.
-- **Fix**: Verificar se `stdio_client.__aexit__` tem timeout interno, adicionar fallback.
-- **Esforço**: M
+#### H4. Connection tester — cleanup incerto no timeout ✅ DONE
+- **Branch**: `fix/2026-02-19-production-hardening-r2`
+- **Fix aplicado**: Extracted _run_connection_test, asyncio.wait_for for proper CancelledError cleanup
+- **Testes**: +3 novos (callable check, timeout message, cleanup message)
 
 ---
 
@@ -173,14 +170,14 @@ Sem corrigir esses 4 problemas, o produto não é confiável para uso real.
 
 ## Problemas MÉDIOS (quality of life)
 
-| # | Problema | Arquivo | Fix | Esforço |
-|---|---------|---------|-----|---------|
-| M1 | httpx sem limites de pool | `server.py` | `Limits(max_connections=10)` | S |
-| M2 | Config reader sync em async | `config/reader.py` | `asyncio.to_thread` | S |
-| M3 | Env vars parser quebra com vírgula no valor | `tools/configure.py` | Documentar ou mudar delimitador | S |
-| M4 | Import inline em loop | `tools/search.py:151` | Mover para topo do arquivo | Trivial |
-| M5 | `shutil.which()` sync no healing | `healing/fixer.py` | Aceitar como debt | Trivial |
-| L1 | Regex de segredos com falsos positivos | `tools/list.py` | Heurísticas por prefixo | S |
+| # | Problema | Arquivo | Fix | Esforço | Status |
+|---|---------|---------|-----|---------|--------|
+| M1 | httpx sem limites de pool | `server.py` | `Limits(max_connections=10)` | S | ✅ DONE |
+| M2 | Config reader sync em async | `config/reader.py` | `asyncio.to_thread` | S | ✅ DONE |
+| M3 | Env vars parser quebra com vírgula no valor | `tools/configure.py` | Regex smart split | S | ✅ DONE |
+| M4 | Import inline em loop | `tools/search.py:151` | Mover para topo do arquivo | Trivial | ✅ DONE |
+| M5 | `shutil.which()` sync no healing | `healing/fixer.py` | Aceitar como debt | Trivial | |
+| L1 | Regex de segredos com falsos positivos | `tools/list.py` | Heurísticas por prefixo | S | |
 
 ---
 

--- a/docs/issues/2026-02-19_production-hardening-round2.md
+++ b/docs/issues/2026-02-19_production-hardening-round2.md
@@ -1,0 +1,94 @@
+# Production Hardening Round 2 — HIGH + MEDIUM bugs
+
+- **Date**: 2026-02-19
+- **Status**: `done`
+- **Branch**: `fix/2026-02-19-production-hardening-r2`
+- **Priority**: `high`
+
+## Problem
+
+7 bugs pendentes do roadmap (3 HIGH + 4 MEDIUM) que afetam resiliência e qualidade de produção:
+
+### HIGH
+- **H2**: Healing loop spawna até 7 processos por servidor (`tools/configure.py`)
+- **H3**: configure_server não é transacional — config escrito mesmo se validação falha
+- **H4**: Connection tester cleanup incerto no timeout (`connection/tester.py`)
+
+### MEDIUM
+- **M1**: httpx sem limites de pool em `server.py` — precisa `Limits(max_connections=10)`
+- **M2**: Config reader é sync em contexto async (`config/reader.py`) — usar `asyncio.to_thread`
+- **M3**: Env vars parser quebra com vírgula no valor (`tools/configure.py`)
+- **M4**: Import inline em loop (`tools/search.py:151`) — mover para topo
+
+## Context
+
+- Bugs documentados em `docs/issues/2026-02-19_premium-quality-roadmap.md`
+- Fase 0 (C1-C4, H1) já corrigidos na sessão anterior
+- Esta é a segunda rodada de hardening
+
+## Root Cause
+
+Múltiplos — ver descrição individual de cada bug acima.
+
+## Solution
+
+### H2: Healing loop reduced (max 7 → max 3 processes)
+- `heal_and_retry()` default `max_attempts` reduced from 3 to 2
+- `_try_heal()` now accepts `original_error` parameter — no longer spawns redundant `test_server_connection` to get a fresh error
+- Removed redundant post-heal `test_server_connection` in `_configure_single()` and `_configure_multi()`
+- `_validate()` now returns 4-tuple including `ConnectionTestResult` for forwarding
+
+### H3: configure_server is now transactional
+- `write_server_config` moved to AFTER validation+healing succeeds
+- If validation fails and healing fails: config NOT written, `success=False`
+- Clear error message: "Config was NOT written to avoid a broken entry"
+- Applied to both `_configure_single()` and `_configure_multi()`
+
+### H4: Connection tester improved cleanup
+- Extracted `_run_connection_test()` coroutine for better separation
+- Replaced `asyncio.timeout` with `asyncio.wait_for` — sends `CancelledError` into coroutine, properly triggering `__aexit__` cleanup of spawned server process
+- Added logging on timeout with process cleanup status
+- Combined nested `async with` into single multi-context (ruff SIM117)
+
+### M1: httpx pool limits
+- Added `limits=httpx.Limits(max_connections=10, max_keepalive_connections=5)` to `httpx.AsyncClient()` in `app_lifespan`
+
+### M2: Async config reader
+- Added `aread_config()` async wrapper using `asyncio.to_thread(read_config, ...)`
+- Sync `read_config` preserved unchanged for sync callers
+
+### M3: Env vars parser with commas in values
+- Replaced naive `env_vars.split(",")` with `re.split(r",(?=\s*[A-Za-z_][A-Za-z0-9_]*\s*=)", env_vars)`
+- Splits only on commas followed by a `KEY=` pattern, preserving commas in values
+
+### M4: Imports moved to top level
+- Moved `import asyncio`, `import httpx`, `RegistryType`, `ServerRecommendation` from inline to top of `tools/search.py`
+
+## Files Changed
+
+### Source (modified)
+- `src/mcp_tap/tools/configure.py` — H2 (reduced process spawning), H3 (transactional writes), M3 (smart env parser)
+- `src/mcp_tap/healing/retry.py` — H2 (max_attempts 3→2)
+- `src/mcp_tap/connection/tester.py` — H4 (wait_for + extracted coroutine)
+- `src/mcp_tap/server.py` — M1 (httpx pool limits)
+- `src/mcp_tap/config/reader.py` — M2 (aread_config async wrapper)
+- `src/mcp_tap/tools/search.py` — M4 (imports moved to top)
+
+### Tests (new/modified)
+- `tests/test_healing.py` — +4 tests (H2: max attempts, error forwarding)
+- `tests/test_tools_configure.py` — +7 tests (H2: no redundant validation, H3: transactional, M3: commas), 2 existing updated for H3
+- `tests/test_connection.py` — +3 tests (H4: cleanup, timeout message)
+- `tests/test_server.py` — +1 test (M1: pool limits)
+- `tests/test_config.py` — +2 tests (M2: aread_config)
+
+## Verification
+
+- [x] Tests pass: `pytest tests/` — 731 passed (714 → 731, +17 new)
+- [x] Linter passes: `ruff check src/ tests/` + `ruff format --check`
+- [x] H2: Healing max 2 attempts (was 3), no redundant process spawns
+- [x] H3: Config NOT written if validation fails, success=False
+- [x] H4: Connection tester uses wait_for for proper cancellation cleanup
+- [x] M1: httpx with Limits(max_connections=10, max_keepalive_connections=5)
+- [x] M2: aread_config async wrapper available
+- [x] M3: Env vars with commas in values parsed correctly
+- [x] M4: Imports moved to top of search.py

--- a/src/mcp_tap/config/reader.py
+++ b/src/mcp_tap/config/reader.py
@@ -6,6 +6,7 @@ We read only "mcpServers", preserve everything else on write.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 
@@ -37,6 +38,11 @@ def read_config(config_path: Path | str) -> dict[str, object]:
         ) from exc
     except PermissionError as exc:
         raise ConfigReadError(f"Permission denied reading {path}: {exc}") from exc
+
+
+async def aread_config(config_path: Path | str) -> dict[str, object]:
+    """Async version of read_config. Use from async code to avoid blocking the event loop."""
+    return await asyncio.to_thread(read_config, config_path)
 
 
 def parse_servers(

--- a/src/mcp_tap/connection/tester.py
+++ b/src/mcp_tap/connection/tester.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
 from mcp.client.session import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
 
 from mcp_tap.models import ConnectionTestResult, ServerConfig
+
+logger = logging.getLogger(__name__)
 
 
 async def test_server_connection(
@@ -20,6 +23,10 @@ async def test_server_connection(
 
     This is the definitive test: if this passes, the server will work
     when the real MCP client runs it.
+
+    Uses ``asyncio.wait_for`` so that on timeout the inner coroutine
+    receives ``CancelledError``, triggering ``stdio_client.__aexit__``
+    cleanup of the spawned server process.
     """
     params = StdioServerParameters(
         command=config.command,
@@ -28,23 +35,22 @@ async def test_server_connection(
     )
 
     try:
-        async with asyncio.timeout(timeout_seconds):
-            async with stdio_client(params) as (read_stream, write_stream):
-                async with ClientSession(read_stream, write_stream) as session:
-                    await session.initialize()
-                    tools_result = await session.list_tools()
-                    tool_names = [t.name for t in tools_result.tools]
-                    return ConnectionTestResult(
-                        success=True,
-                        server_name=server_name,
-                        tools_discovered=tool_names,
-                    )
+        return await asyncio.wait_for(
+            _run_connection_test(server_name, params),
+            timeout=timeout_seconds,
+        )
     except TimeoutError:
+        logger.warning(
+            "Connection test for '%s' timed out after %ds; process cleanup was attempted",
+            server_name,
+            timeout_seconds,
+        )
         return ConnectionTestResult(
             success=False,
             server_name=server_name,
             error=(
-                f"Server did not respond within {timeout_seconds}s. "
+                f"Server did not respond within {timeout_seconds}s "
+                "(process cleanup was attempted). "
                 "Check that the command exists, required env vars are set, "
                 "and the server supports stdio transport."
             ),
@@ -60,4 +66,27 @@ async def test_server_connection(
             success=False,
             server_name=server_name,
             error=f"{type(exc).__name__}: {exc}",
+        )
+
+
+async def _run_connection_test(
+    server_name: str,
+    params: StdioServerParameters,
+) -> ConnectionTestResult:
+    """Run the actual connection test inside ``stdio_client`` context.
+
+    Separated so that ``asyncio.wait_for`` can cancel this coroutine on
+    timeout, which triggers the async context managers' cleanup paths.
+    """
+    async with (
+        stdio_client(params) as (read_stream, write_stream),
+        ClientSession(read_stream, write_stream) as session,
+    ):
+        await session.initialize()
+        tools_result = await session.list_tools()
+        tool_names = [t.name for t in tools_result.tools]
+        return ConnectionTestResult(
+            success=True,
+            server_name=server_name,
+            tools_discovered=tool_names,
         )

--- a/src/mcp_tap/healing/retry.py
+++ b/src/mcp_tap/healing/retry.py
@@ -25,7 +25,7 @@ async def heal_and_retry(
     server_config: ServerConfig,
     error: ConnectionTestResult,
     *,
-    max_attempts: int = 3,
+    max_attempts: int = 2,
     timeout_seconds: int = 15,
 ) -> HealingResult:
     """Diagnose an error, apply a fix, and retry validation.

--- a/src/mcp_tap/server.py
+++ b/src/mcp_tap/server.py
@@ -37,6 +37,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
     async with httpx.AsyncClient(
         timeout=httpx.Timeout(30.0, connect=10.0),
         follow_redirects=True,
+        limits=httpx.Limits(max_connections=10, max_keepalive_connections=5),
         transport=httpx.AsyncHTTPTransport(retries=3),
     ) as http_client:
         registry = RegistryClient(http_client)

--- a/src/mcp_tap/tools/search.py
+++ b/src/mcp_tap/tools/search.py
@@ -2,15 +2,23 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import asdict
 
+import httpx
 from mcp.server.fastmcp import Context
 
 from mcp_tap.errors import McpTapError
 from mcp_tap.evaluation.github import fetch_repo_metadata
 from mcp_tap.evaluation.scorer import score_maturity
-from mcp_tap.models import MaturitySignals, ProjectProfile, SearchResult
+from mcp_tap.models import (
+    MaturitySignals,
+    ProjectProfile,
+    RegistryType,
+    SearchResult,
+    ServerRecommendation,
+)
 from mcp_tap.scanner.credentials import map_credentials
 from mcp_tap.scanner.scoring import relevance_sort_key, score_result
 
@@ -148,8 +156,6 @@ def _apply_credential_status(
         reg_vars = {pkg_id: list(env_vars_required)} if pkg_id else {}
 
         # Create a minimal recommendation for mapping
-        from mcp_tap.models import RegistryType, ServerRecommendation
-
         rec = ServerRecommendation(
             server_name=str(result.get("name", "")),
             package_identifier=pkg_id,
@@ -186,10 +192,6 @@ async def _apply_maturity(
     http_client: object,
 ) -> list[dict[str, object]]:
     """Fetch GitHub maturity signals and add scores to results."""
-    import asyncio
-
-    import httpx
-
     if not isinstance(http_client, httpx.AsyncClient):
         return results
 


### PR DESCRIPTION
## Summary
- **H2**: Reduce healing process spawns from max 7 to max 3 (reuse original error, remove redundant post-heal validation, max_attempts 3→2)
- **H3**: Make configure_server transactional — config only written after validation passes, returns `success=False` on failure
- **H4**: Use `asyncio.wait_for` in connection tester for proper cancellation cleanup of spawned server processes on timeout
- **M1**: Add httpx pool limits (`max_connections=10, max_keepalive=5`)
- **M2**: Add `aread_config` async wrapper via `asyncio.to_thread`
- **M3**: Smart env vars parser preserves commas in values via regex split
- **M4**: Move inline imports to top level in `tools/search.py`

## Test plan
- [x] 731 tests passing (714 + 17 new)
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI passes on PR