### PR TITLE
Add conversational stacks: shareable MCP server profiles (I3)

### DIFF
--- a/docs/issues/2026-02-19_conversational-stacks.md
+++ b/docs/issues/2026-02-19_conversational-stacks.md
@@ -1,0 +1,34 @@
+# I3 — Conversational Stacks (.mcp-tap.yaml)
+
+- **Date**: 2026-02-19
+- **Status**: `in_progress`
+- **Branch**: `feature/2026-02-19-conversational-stacks`
+- **Priority**: `high`
+
+## Problem
+
+No way to share or reproduce MCP server setups. Users must manually configure
+each server one by one. Competitor mcp-compose does manual composition —
+mcp-tap should do it intelligently and conversationally.
+
+## Context
+
+- Roadmap item I3 in `docs/issues/2026-02-19_premium-quality-roadmap.md`
+- Impact: 8/10 | Effort: M
+- Creates network effects (shareable stacks = UGC flywheel)
+
+## Solution
+
+YAML-based stack format + `apply_stack` tool + 3 built-in stacks.
+
+## Files Changed
+
+(Fill after implementation)
+
+## Verification
+
+- [ ] Tests pass: `pytest tests/`
+- [ ] Linter passes: `ruff check src/ tests/`
+- [ ] apply_stack installs from built-in stack names
+- [ ] apply_stack installs from custom YAML file path
+- [ ] 3 built-in stacks: data-science, web-dev, devops

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 dependencies = [
     "mcp>=1.12.0",
     "httpx>=0.27.0",
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]

--- a/src/mcp_tap/models.py
+++ b/src/mcp_tap/models.py
@@ -463,3 +463,28 @@ class SecurityReport:
     @property
     def blockers(self) -> list[SecuritySignal]:
         return [s for s in self.signals if s.risk == SecurityRisk.BLOCK]
+
+
+# ─── Stack Models ────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class StackServer:
+    """A single server entry in a stack definition."""
+
+    name: str
+    package_identifier: str
+    registry_type: str = "npm"
+    version: str = "latest"
+    env_vars: list[str] = field(default_factory=list)  # names only, user provides values
+
+
+@dataclass(frozen=True, slots=True)
+class Stack:
+    """A shareable MCP server profile."""
+
+    name: str
+    description: str
+    servers: list[StackServer] = field(default_factory=list)
+    version: str = "1"
+    author: str = ""

--- a/src/mcp_tap/server.py
+++ b/src/mcp_tap/server.py
@@ -19,6 +19,7 @@ from mcp_tap.tools.remove import remove_server
 from mcp_tap.tools.restore import restore
 from mcp_tap.tools.scan import scan_project
 from mcp_tap.tools.search import search_servers
+from mcp_tap.tools.stack import apply_stack
 from mcp_tap.tools.test import test_connection
 from mcp_tap.tools.verify import verify
 
@@ -121,3 +122,4 @@ mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))(verify)
 mcp.tool(annotations=ToolAnnotations(destructiveHint=True))(configure_server)
 mcp.tool(annotations=ToolAnnotations(destructiveHint=True))(remove_server)
 mcp.tool(annotations=ToolAnnotations(destructiveHint=True))(restore)
+mcp.tool(annotations=ToolAnnotations(destructiveHint=True))(apply_stack)

--- a/src/mcp_tap/stacks/__init__.py
+++ b/src/mcp_tap/stacks/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/src/mcp_tap/stacks/loader.py
+++ b/src/mcp_tap/stacks/loader.py
@@ -1,0 +1,128 @@
+"""Load stack definitions from YAML files or built-in presets."""
+
+from __future__ import annotations
+
+import importlib.resources
+import logging
+from pathlib import Path
+
+import yaml
+
+from mcp_tap.errors import McpTapError
+from mcp_tap.models import Stack, StackServer
+
+logger = logging.getLogger(__name__)
+
+# Built-in stack names
+BUILTIN_STACKS = {"data-science", "web-dev", "devops"}
+
+
+def load_stack(name_or_path: str) -> Stack:
+    """Load a stack by built-in name or file path.
+
+    Args:
+        name_or_path: Either a built-in stack name (e.g. "data-science")
+            or a path to a .yaml/.yml file.
+
+    Returns:
+        Parsed Stack object.
+
+    Raises:
+        McpTapError: If the stack cannot be loaded or parsed.
+    """
+    path = Path(name_or_path)
+    if path.suffix in (".yaml", ".yml") or path.exists():
+        return _load_from_file(path)
+
+    if name_or_path in BUILTIN_STACKS:
+        return _load_builtin(name_or_path)
+
+    raise McpTapError(
+        f"Unknown stack '{name_or_path}'. "
+        f"Available built-in stacks: {', '.join(sorted(BUILTIN_STACKS))}. "
+        "Or provide a path to a .yaml file."
+    )
+
+
+def list_builtin_stacks() -> list[dict[str, object]]:
+    """Return metadata about all built-in stacks."""
+    result: list[dict[str, object]] = []
+    for name in sorted(BUILTIN_STACKS):
+        try:
+            stack = _load_builtin(name)
+            result.append(
+                {
+                    "name": stack.name,
+                    "description": stack.description,
+                    "server_count": len(stack.servers),
+                    "author": stack.author,
+                }
+            )
+        except Exception:
+            result.append({"name": name, "description": "Failed to load", "server_count": 0})
+    return result
+
+
+def _load_builtin(name: str) -> Stack:
+    """Load a built-in stack from package resources."""
+    try:
+        ref = importlib.resources.files("mcp_tap.stacks") / "presets" / f"{name}.yaml"
+        text = ref.read_text(encoding="utf-8")
+        return _parse_yaml(text, source=f"builtin:{name}")
+    except FileNotFoundError:
+        raise McpTapError(f"Built-in stack '{name}' not found.") from None
+    except McpTapError:
+        raise
+    except Exception as exc:
+        raise McpTapError(f"Failed to load built-in stack '{name}': {exc}") from exc
+
+
+def _load_from_file(path: Path) -> Stack:
+    """Load a stack from a YAML file on disk."""
+    if not path.exists():
+        raise McpTapError(f"Stack file not found: {path}")
+    try:
+        text = path.read_text(encoding="utf-8")
+        return _parse_yaml(text, source=str(path))
+    except McpTapError:
+        raise
+    except Exception as exc:
+        raise McpTapError(f"Failed to parse stack file '{path}': {exc}") from exc
+
+
+def _parse_yaml(text: str, source: str = "") -> Stack:
+    """Parse YAML text into a Stack object."""
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        raise McpTapError(f"Invalid stack format in {source}: expected a YAML mapping.")
+
+    name = data.get("name", "unnamed")
+    description = data.get("description", "")
+    version = str(data.get("version", "1"))
+    author = data.get("author", "")
+
+    servers_data = data.get("servers", [])
+    if not isinstance(servers_data, list):
+        raise McpTapError(f"Invalid stack format in {source}: 'servers' must be a list.")
+
+    servers: list[StackServer] = []
+    for entry in servers_data:
+        if not isinstance(entry, dict):
+            continue
+        servers.append(
+            StackServer(
+                name=entry.get("name", ""),
+                package_identifier=entry.get("package", ""),
+                registry_type=entry.get("registry", "npm"),
+                version=str(entry.get("version", "latest")),
+                env_vars=list(entry.get("env_vars", [])),
+            )
+        )
+
+    return Stack(
+        name=name,
+        description=description,
+        servers=servers,
+        version=version,
+        author=author,
+    )

--- a/src/mcp_tap/stacks/presets/data-science.yaml
+++ b/src/mcp_tap/stacks/presets/data-science.yaml
@@ -1,0 +1,15 @@
+name: data-science
+description: "MCP servers for data science workflows: Jupyter, database access, and file handling."
+version: "1"
+author: mcp-tap
+servers:
+  - name: sqlite
+    package: "@modelcontextprotocol/server-sqlite"
+    registry: npm
+  - name: postgres
+    package: "@modelcontextprotocol/server-postgres"
+    registry: npm
+    env_vars: [POSTGRES_URL]
+  - name: puppeteer
+    package: "@modelcontextprotocol/server-puppeteer"
+    registry: npm

--- a/src/mcp_tap/stacks/presets/devops.yaml
+++ b/src/mcp_tap/stacks/presets/devops.yaml
@@ -1,0 +1,16 @@
+name: devops
+description: "MCP servers for DevOps workflows: Docker, Kubernetes, and cloud infrastructure."
+version: "1"
+author: mcp-tap
+servers:
+  - name: docker
+    package: "mcp-server-docker"
+    registry: pypi
+  - name: github
+    package: "@modelcontextprotocol/server-github"
+    registry: npm
+    env_vars: [GITHUB_PERSONAL_ACCESS_TOKEN]
+  - name: slack
+    package: "@modelcontextprotocol/server-slack"
+    registry: npm
+    env_vars: [SLACK_BOT_TOKEN, SLACK_TEAM_ID]

--- a/src/mcp_tap/stacks/presets/web-dev.yaml
+++ b/src/mcp_tap/stacks/presets/web-dev.yaml
@@ -1,0 +1,16 @@
+name: web-dev
+description: "MCP servers for web development: browser automation, GitHub, and Sentry."
+version: "1"
+author: mcp-tap
+servers:
+  - name: puppeteer
+    package: "@modelcontextprotocol/server-puppeteer"
+    registry: npm
+  - name: github
+    package: "@modelcontextprotocol/server-github"
+    registry: npm
+    env_vars: [GITHUB_PERSONAL_ACCESS_TOKEN]
+  - name: sentry
+    package: "@modelcontextprotocol/server-sentry"
+    registry: npm
+    env_vars: [SENTRY_AUTH_TOKEN, SENTRY_ORG]

--- a/src/mcp_tap/tools/stack.py
+++ b/src/mcp_tap/tools/stack.py
@@ -1,0 +1,126 @@
+"""apply_stack tool -- install a group of MCP servers from a stack definition."""
+
+from __future__ import annotations
+
+import logging
+
+from mcp.server.fastmcp import Context
+
+from mcp_tap.errors import McpTapError
+from mcp_tap.stacks.loader import list_builtin_stacks, load_stack
+from mcp_tap.tools.configure import configure_server
+
+logger = logging.getLogger(__name__)
+
+
+async def apply_stack(
+    stack: str,
+    ctx: Context,
+    clients: str = "",
+    scope: str = "user",
+    project_path: str = "",
+    dry_run: bool = False,
+) -> dict[str, object]:
+    """Install a group of MCP servers from a stack definition.
+
+    Stacks are shareable profiles that bundle multiple MCP servers together.
+    Use a built-in stack name or a path to a .yaml file.
+
+    Built-in stacks: data-science, web-dev, devops.
+    Use dry_run=True to preview what would be installed without making changes.
+
+    Args:
+        stack: Built-in stack name (e.g. "data-science") or path to .yaml file.
+        clients: Target MCP client(s). Same as configure_server.
+        scope: "user" or "project". Same as configure_server.
+        project_path: Project directory path. Required when scope="project".
+        dry_run: If True, only show what would be installed without installing.
+
+    Returns:
+        Result with: stack_name, servers_total, servers_installed, servers_failed,
+        per_server_results, and any env_vars_needed.
+    """
+    try:
+        stack_def = load_stack(stack)
+    except McpTapError as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "available_stacks": list_builtin_stacks(),
+        }
+
+    if not stack_def.servers:
+        return {
+            "success": False,
+            "error": f"Stack '{stack_def.name}' has no servers defined.",
+        }
+
+    # Collect env vars needed across all servers
+    env_vars_needed: list[str] = []
+    for srv in stack_def.servers:
+        env_vars_needed.extend(srv.env_vars)
+
+    if dry_run:
+        return {
+            "success": True,
+            "dry_run": True,
+            "stack_name": stack_def.name,
+            "description": stack_def.description,
+            "servers_total": len(stack_def.servers),
+            "servers": [
+                {
+                    "name": s.name,
+                    "package": s.package_identifier,
+                    "registry": s.registry_type,
+                    "env_vars_needed": s.env_vars,
+                }
+                for s in stack_def.servers
+            ],
+            "env_vars_needed": sorted(set(env_vars_needed)),
+        }
+
+    # Install each server sequentially
+    await ctx.info(f"Applying stack '{stack_def.name}' ({len(stack_def.servers)} servers)...")
+
+    results: list[dict[str, object]] = []
+    installed = 0
+    failed = 0
+
+    for srv in stack_def.servers:
+        await ctx.info(f"Installing {srv.name} ({srv.package_identifier})...")
+        try:
+            result = await configure_server(
+                server_name=srv.name,
+                package_identifier=srv.package_identifier,
+                ctx=ctx,
+                clients=clients,
+                registry_type=srv.registry_type,
+                version=srv.version,
+                scope=scope,
+                project_path=project_path,
+            )
+            results.append({"server": srv.name, **result})
+            if result.get("success"):
+                installed += 1
+            else:
+                failed += 1
+        except Exception as exc:
+            results.append(
+                {
+                    "server": srv.name,
+                    "success": False,
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+            )
+            failed += 1
+
+    return {
+        "success": installed > 0,
+        "stack_name": stack_def.name,
+        "description": stack_def.description,
+        "servers_total": len(stack_def.servers),
+        "servers_installed": installed,
+        "servers_failed": failed,
+        "per_server_results": results,
+        "env_vars_needed": sorted(set(env_vars_needed)),
+    }

--- a/tests/test_stacks.py
+++ b/tests/test_stacks.py
@@ -1,0 +1,350 @@
+"""Tests for the stacks module (loader, tool, and models)."""
+
+from __future__ import annotations
+
+import textwrap
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_tap.errors import McpTapError
+from mcp_tap.models import Stack, StackServer
+from mcp_tap.stacks.loader import (
+    BUILTIN_STACKS,
+    _parse_yaml,
+    list_builtin_stacks,
+    load_stack,
+)
+from mcp_tap.tools.stack import apply_stack
+
+# ─── Helpers ─────────────────────────────────────────────────
+
+
+def _make_ctx() -> MagicMock:
+    """Build a mock Context with async info/error methods."""
+    ctx = MagicMock()
+    ctx.info = AsyncMock()
+    ctx.error = AsyncMock()
+    return ctx
+
+
+MINIMAL_YAML = textwrap.dedent("""\
+    name: test-stack
+    description: A test stack
+    servers:
+      - name: foo
+        package: "@test/server-foo"
+""")
+
+FULL_YAML = textwrap.dedent("""\
+    name: full-stack
+    description: Stack with all fields
+    version: "2"
+    author: tester
+    servers:
+      - name: alpha
+        package: "@test/alpha"
+        registry: npm
+        version: "1.2.3"
+        env_vars: [ALPHA_KEY, ALPHA_SECRET]
+      - name: beta
+        package: "mcp-server-beta"
+        registry: pypi
+        version: "0.5.0"
+        env_vars: [BETA_TOKEN]
+""")
+
+
+# ─── Loader tests ────────────────────────────────────────────
+
+
+class TestLoadBuiltinStacks:
+    def test_load_builtin_data_science(self) -> None:
+        stack = load_stack("data-science")
+        assert stack.name == "data-science"
+        assert len(stack.servers) == 3
+        names = [s.name for s in stack.servers]
+        assert "sqlite" in names
+        assert "postgres" in names
+
+    def test_load_builtin_web_dev(self) -> None:
+        stack = load_stack("web-dev")
+        assert stack.name == "web-dev"
+        assert len(stack.servers) == 3
+        names = [s.name for s in stack.servers]
+        assert "puppeteer" in names
+        assert "github" in names
+
+    def test_load_builtin_devops(self) -> None:
+        stack = load_stack("devops")
+        assert stack.name == "devops"
+        assert len(stack.servers) == 3
+        names = [s.name for s in stack.servers]
+        assert "docker" in names
+        assert "slack" in names
+
+    def test_load_unknown_stack_raises(self) -> None:
+        with pytest.raises(McpTapError, match="Unknown stack 'nonexistent'"):
+            load_stack("nonexistent")
+
+
+class TestLoadFromFile:
+    def test_load_yaml_file(self, tmp_path: object) -> None:
+        path = tmp_path / "my-stack.yaml"  # type: ignore[operator]
+        path.write_text(MINIMAL_YAML)  # type: ignore[union-attr]
+        stack = load_stack(str(path))
+        assert stack.name == "test-stack"
+        assert len(stack.servers) == 1
+        assert stack.servers[0].name == "foo"
+        assert stack.servers[0].package_identifier == "@test/server-foo"
+
+    def test_load_yml_extension(self, tmp_path: object) -> None:
+        path = tmp_path / "stack.yml"  # type: ignore[operator]
+        path.write_text(MINIMAL_YAML)  # type: ignore[union-attr]
+        stack = load_stack(str(path))
+        assert stack.name == "test-stack"
+
+    def test_load_nonexistent_file_raises(self) -> None:
+        with pytest.raises(McpTapError, match="Stack file not found"):
+            load_stack("/nonexistent/path.yaml")
+
+    def test_load_invalid_yaml_raises(self, tmp_path: object) -> None:
+        path = tmp_path / "bad.yaml"  # type: ignore[operator]
+        path.write_text("- just\n- a\n- list\n")  # type: ignore[union-attr]
+        with pytest.raises(McpTapError, match="expected a YAML mapping"):
+            load_stack(str(path))
+
+
+class TestParseYaml:
+    def test_parse_yaml_with_all_fields(self) -> None:
+        stack = _parse_yaml(FULL_YAML, source="test")
+        assert stack.name == "full-stack"
+        assert stack.description == "Stack with all fields"
+        assert stack.version == "2"
+        assert stack.author == "tester"
+        assert len(stack.servers) == 2
+
+        alpha = stack.servers[0]
+        assert alpha.name == "alpha"
+        assert alpha.package_identifier == "@test/alpha"
+        assert alpha.registry_type == "npm"
+        assert alpha.version == "1.2.3"
+        assert alpha.env_vars == ["ALPHA_KEY", "ALPHA_SECRET"]
+
+        beta = stack.servers[1]
+        assert beta.name == "beta"
+        assert beta.package_identifier == "mcp-server-beta"
+        assert beta.registry_type == "pypi"
+        assert beta.version == "0.5.0"
+        assert beta.env_vars == ["BETA_TOKEN"]
+
+    def test_parse_yaml_minimal(self) -> None:
+        stack = _parse_yaml(MINIMAL_YAML, source="test")
+        assert stack.name == "test-stack"
+        assert stack.version == "1"
+        assert stack.author == ""
+        assert len(stack.servers) == 1
+        assert stack.servers[0].registry_type == "npm"
+        assert stack.servers[0].version == "latest"
+        assert stack.servers[0].env_vars == []
+
+    def test_load_empty_servers_list(self) -> None:
+        yaml_text = "name: empty\ndescription: No servers\nservers: []\n"
+        stack = _parse_yaml(yaml_text, source="test")
+        assert stack.name == "empty"
+        assert stack.servers == []
+
+    def test_parse_yaml_invalid_servers_type(self) -> None:
+        yaml_text = "name: bad\nservers: not-a-list\n"
+        with pytest.raises(McpTapError, match="'servers' must be a list"):
+            _parse_yaml(yaml_text, source="test")
+
+    def test_parse_yaml_skips_non_dict_entries(self) -> None:
+        yaml_text = textwrap.dedent("""\
+            name: mixed
+            description: Has non-dict entries
+            servers:
+              - name: valid
+                package: "@test/valid"
+              - "just a string"
+        """)
+        stack = _parse_yaml(yaml_text, source="test")
+        assert len(stack.servers) == 1
+        assert stack.servers[0].name == "valid"
+
+
+class TestListBuiltinStacks:
+    def test_list_builtin_stacks(self) -> None:
+        stacks = list_builtin_stacks()
+        assert len(stacks) == len(BUILTIN_STACKS)
+        names = {s["name"] for s in stacks}
+        assert names == BUILTIN_STACKS
+        for s in stacks:
+            assert "description" in s
+            assert "server_count" in s
+            assert s["server_count"] > 0
+
+
+# ─── Tool tests ──────────────────────────────────────────────
+
+
+class TestApplyStackDryRun:
+    async def test_apply_stack_dry_run(self) -> None:
+        ctx = _make_ctx()
+        result = await apply_stack(stack="data-science", ctx=ctx, dry_run=True)
+        assert result["success"] is True
+        assert result["dry_run"] is True
+        assert result["stack_name"] == "data-science"
+        assert result["servers_total"] == 3
+        assert isinstance(result["servers"], list)
+        assert isinstance(result["env_vars_needed"], list)
+        assert "POSTGRES_URL" in result["env_vars_needed"]
+
+    async def test_apply_stack_dry_run_from_yaml_file(self, tmp_path: object) -> None:
+        path = tmp_path / "custom.yaml"  # type: ignore[operator]
+        path.write_text(FULL_YAML)  # type: ignore[union-attr]
+        ctx = _make_ctx()
+        result = await apply_stack(stack=str(path), ctx=ctx, dry_run=True)
+        assert result["success"] is True
+        assert result["stack_name"] == "full-stack"
+        assert result["servers_total"] == 2
+
+
+class TestApplyStackInstall:
+    @patch("mcp_tap.tools.stack.configure_server")
+    async def test_apply_stack_installs_all(self, mock_configure: AsyncMock) -> None:
+        mock_configure.return_value = {"success": True, "server_name": "test"}
+        ctx = _make_ctx()
+        result = await apply_stack(stack="data-science", ctx=ctx)
+        assert result["success"] is True
+        assert result["servers_installed"] == 3
+        assert result["servers_failed"] == 0
+        assert mock_configure.call_count == 3
+
+    @patch("mcp_tap.tools.stack.configure_server")
+    async def test_apply_stack_partial_failure(self, mock_configure: AsyncMock) -> None:
+        mock_configure.side_effect = [
+            {"success": True, "server_name": "sqlite"},
+            {"success": False, "server_name": "postgres", "message": "failed"},
+            {"success": True, "server_name": "puppeteer"},
+        ]
+        ctx = _make_ctx()
+        result = await apply_stack(stack="data-science", ctx=ctx)
+        assert result["success"] is True  # at least one installed
+        assert result["servers_installed"] == 2
+        assert result["servers_failed"] == 1
+
+    @patch("mcp_tap.tools.stack.configure_server")
+    async def test_apply_stack_all_fail(self, mock_configure: AsyncMock) -> None:
+        mock_configure.return_value = {"success": False, "message": "failed"}
+        ctx = _make_ctx()
+        result = await apply_stack(stack="data-science", ctx=ctx)
+        assert result["success"] is False
+        assert result["servers_installed"] == 0
+        assert result["servers_failed"] == 3
+
+    @patch("mcp_tap.tools.stack.configure_server")
+    async def test_apply_stack_exception_handling(self, mock_configure: AsyncMock) -> None:
+        mock_configure.side_effect = RuntimeError("boom")
+        ctx = _make_ctx()
+        result = await apply_stack(stack="data-science", ctx=ctx)
+        assert result["success"] is False
+        assert result["servers_failed"] == 3
+        per_server = result["per_server_results"]
+        assert "RuntimeError: boom" in per_server[0]["error"]
+
+    async def test_apply_stack_unknown_stack(self) -> None:
+        ctx = _make_ctx()
+        result = await apply_stack(stack="nonexistent", ctx=ctx)
+        assert result["success"] is False
+        assert "error" in result
+        assert "available_stacks" in result
+
+    @patch("mcp_tap.tools.stack.configure_server")
+    async def test_apply_stack_empty_stack(self, mock_configure: AsyncMock) -> None:
+        ctx = _make_ctx()
+        with patch("mcp_tap.tools.stack.load_stack") as mock_load:
+            mock_load.return_value = Stack(name="empty", description="No servers", servers=[])
+            result = await apply_stack(stack="empty", ctx=ctx)
+        assert result["success"] is False
+        assert "no servers" in result["error"].lower()
+        mock_configure.assert_not_called()
+
+    @patch("mcp_tap.tools.stack.configure_server")
+    async def test_apply_stack_env_vars_collected(self, mock_configure: AsyncMock) -> None:
+        mock_configure.return_value = {"success": True}
+        ctx = _make_ctx()
+        result = await apply_stack(stack="web-dev", ctx=ctx)
+        env_vars = result["env_vars_needed"]
+        assert "GITHUB_PERSONAL_ACCESS_TOKEN" in env_vars
+        assert "SENTRY_AUTH_TOKEN" in env_vars
+        assert "SENTRY_ORG" in env_vars
+
+    @patch("mcp_tap.tools.stack.configure_server")
+    async def test_apply_stack_from_yaml_file(
+        self, mock_configure: AsyncMock, tmp_path: object
+    ) -> None:
+        mock_configure.return_value = {"success": True}
+        path = tmp_path / "custom.yaml"  # type: ignore[operator]
+        path.write_text(FULL_YAML)  # type: ignore[union-attr]
+        ctx = _make_ctx()
+        result = await apply_stack(stack=str(path), ctx=ctx)
+        assert result["success"] is True
+        assert result["stack_name"] == "full-stack"
+        assert mock_configure.call_count == 2
+
+    @patch("mcp_tap.tools.stack.configure_server")
+    async def test_apply_stack_passes_clients_and_scope(self, mock_configure: AsyncMock) -> None:
+        mock_configure.return_value = {"success": True}
+        ctx = _make_ctx()
+        await apply_stack(
+            stack="data-science",
+            ctx=ctx,
+            clients="claude_desktop,cursor",
+            scope="project",
+            project_path="/some/project",
+        )
+        for call in mock_configure.call_args_list:
+            assert call.kwargs["clients"] == "claude_desktop,cursor"
+            assert call.kwargs["scope"] == "project"
+            assert call.kwargs["project_path"] == "/some/project"
+
+
+# ─── Model tests ─────────────────────────────────────────────
+
+
+class TestStackModels:
+    def test_stack_model_frozen(self) -> None:
+        stack = Stack(name="test", description="desc")
+        with pytest.raises(AttributeError):
+            stack.name = "changed"  # type: ignore[misc]
+
+    def test_stack_server_frozen(self) -> None:
+        srv = StackServer(name="test", package_identifier="pkg")
+        with pytest.raises(AttributeError):
+            srv.name = "changed"  # type: ignore[misc]
+
+    def test_stack_server_defaults(self) -> None:
+        srv = StackServer(name="test", package_identifier="pkg")
+        assert srv.registry_type == "npm"
+        assert srv.version == "latest"
+        assert srv.env_vars == []
+
+    def test_stack_defaults(self) -> None:
+        stack = Stack(name="test", description="desc")
+        assert stack.servers == []
+        assert stack.version == "1"
+        assert stack.author == ""
+
+    def test_stack_from_yaml_roundtrip(self) -> None:
+        stack = _parse_yaml(FULL_YAML, source="test")
+        assert stack.name == "full-stack"
+        assert stack.description == "Stack with all fields"
+        assert stack.version == "2"
+        assert stack.author == "tester"
+        assert len(stack.servers) == 2
+        assert stack.servers[0].name == "alpha"
+        assert stack.servers[0].package_identifier == "@test/alpha"
+        assert stack.servers[0].env_vars == ["ALPHA_KEY", "ALPHA_SECRET"]
+        assert stack.servers[1].name == "beta"
+        assert stack.servers[1].registry_type == "pypi"


### PR DESCRIPTION
## Summary
- New `apply_stack` tool (11th MCP tool) installs groups of servers from YAML stack definitions
- 3 built-in stacks: `data-science`, `web-dev`, `devops`
- Supports custom `.yaml` files and `dry_run` preview mode
- New models: `Stack`, `StackServer`
- New dependency: `pyyaml>=6.0`

## Test plan
- [x] 800 tests passing (770 + 30 new)
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI passes on PR