### PR TITLE
Use OIDC trusted publishing for npm releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
       - v*
 
 jobs:
-  publish:
+  publish-pypi:
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -31,5 +31,27 @@ jobs:
       - name: Smoke test (source distribution)
         run: uv run --isolated --no-project --with dist/*.tar.gz tests/smoke_test.py
 
-      - name: Publish
+      - name: Publish to PyPI
         run: uv publish
+
+  publish-npm:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Sync version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          cd npm-wrapper
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+      - name: Publish to npm
+        run: cd npm-wrapper && npm publish --provenance --access public


### PR DESCRIPTION
## Summary

- Replace `NPM_TOKEN` secret with OIDC trusted publishing for npm
- Adds `id-token: write` permission and `--provenance --access public` flags
- Node.js bumped to 22 (required for npm OIDC support)
- Zero secrets needed — both PyPI and npm now use trusted publishing

## Setup required (one-time)

Configure trusted publisher on npmjs.com:
1. https://www.npmjs.com/package/mcp-tap → Settings → Trusted Publisher
2. Select GitHub Actions → user: `felipestenzel`, repo: `mcp-tap`, workflow: `publish.yml`

## Test plan

- [x] Workflow YAML is valid
- [ ] Next release (`v0.3.1+`) will verify automated npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)