### PR TITLE
Add npm README + update docs for v0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ You install mcp-tap once. It installs everything else.
 
 Add to your `claude_desktop_config.json`:
 
+<!-- tabs: uvx (recommended), npx -->
+
+**With uvx** (recommended):
+
 ```json
 {
   "mcpServers": {
@@ -59,10 +63,27 @@ Add to your `claude_desktop_config.json`:
 }
 ```
 
+**With npx**:
+
+```json
+{
+  "mcpServers": {
+    "mcp-tap": {
+      "command": "npx",
+      "args": ["-y", "mcp-tap"]
+    }
+  }
+}
+```
+
 ### Claude Code
 
 ```bash
+# With uvx (recommended)
 claude mcp add mcp-tap -- uvx mcp-tap
+
+# With npx
+claude mcp add mcp-tap -- npx -y mcp-tap
 ```
 
 ### Cursor
@@ -80,6 +101,8 @@ Add to `.cursor/mcp.json`:
 }
 ```
 
+Or use `npx` — replace `"command": "uvx", "args": ["mcp-tap"]` with `"command": "npx", "args": ["-y", "mcp-tap"]`.
+
 ### Windsurf
 
 Add to `~/.codeium/windsurf/mcp_config.json`:
@@ -94,6 +117,8 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
   }
 }
 ```
+
+Or use `npx` — replace `"command": "uvx", "args": ["mcp-tap"]` with `"command": "npx", "args": ["-y", "mcp-tap"]`.
 
 ## What can it do?
 
@@ -112,27 +137,36 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 
 | Tool | What it does |
 |------|-------------|
-| `scan_project` | Scans your project directory, detects languages/frameworks/databases, recommends MCP servers |
-| `search_servers` | Searches the MCP Registry by keyword, optionally ranked by project relevance |
-| `configure_server` | Installs a package (npm/pip/docker) and writes config to one or all clients |
-| `test_connection` | Spawns a server process, connects via MCP, and lists its tools |
-| `check_health` | Tests all configured servers concurrently, reports healthy/unhealthy/timeout |
-| `list_installed` | Shows all configured servers with their commands and environment variables (secrets masked) |
+| `scan_project` | Scans your project directory — detects languages, frameworks, databases, CI/CD pipelines — and recommends MCP servers |
+| `search_servers` | Searches the MCP Registry by keyword, with maturity scoring and project relevance ranking |
+| `configure_server` | Installs a package (npm/pip/docker), runs a security gate, validates the connection, and writes config |
+| `test_connection` | Spawns a server process, connects via MCP protocol, and lists its tools. Auto-heals on failure |
+| `check_health` | Tests all configured servers concurrently, detects tool conflicts between servers |
+| `inspect_server` | Fetches a server's README and extracts configuration hints |
+| `list_installed` | Shows all configured servers with secrets masked (layered detection: key names, prefixes, high-entropy) |
 | `remove_server` | Removes a server from one or all client configs |
+| `verify` | Compares `mcp-tap.lock` against actual config — detects drift |
+| `restore` | Recreates server configs from a lockfile (like `npm ci` for MCP) |
+| `apply_stack` | Installs a group of servers from a shareable stack profile |
+
+Plus automatic lockfile management on every configure/remove.
 
 ## Features
 
-- **Project-aware**: Scans your codebase to recommend servers based on your actual stack
+- **Project-aware**: Scans your codebase — including CI/CD configs (GitHub Actions, GitLab CI) — to recommend servers based on your actual stack
+- **Security gate**: Blocks suspicious install commands, archived repos, and known-risky patterns before installing
+- **Lockfile**: `mcp-tap.lock` tracks exact versions and hashes of all your MCP servers. Reproducible setups across machines
+- **Stacks**: Shareable server profiles — install a complete Data Science, Web Dev, or DevOps stack in one command
 - **Multi-client**: Configure Claude Desktop, Claude Code, Cursor, and Windsurf — all at once or individually
-- **Project-scoped configs**: Use `scope="project"` to write `.mcp.json` for team-shared setups
+- **Auto-healing**: Failed connections are automatically diagnosed and fixed when possible
+- **Tool conflict detection**: Warns when two servers expose overlapping tools that could confuse the LLM
 - **Connection validation**: Every install is verified with a real MCP connection test
-- **Health monitoring**: Check all your servers in one command
 - **Secrets masked**: `list_installed` never exposes environment variable values
 
 ## Requirements
 
-- Python 3.11+
-- [`uv`](https://docs.astral.sh/uv/) (recommended) or `pip`
+- Python 3.11+ with [`uv`](https://docs.astral.sh/uv/) (recommended), **or**
+- Node.js 18+ (the npm package is a thin wrapper that calls the Python package via `uvx`/`pipx`)
 
 ## License
 

--- a/npm-wrapper/LICENSE
+++ b/npm-wrapper/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Felipe Stenzel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm-wrapper/README.md
+++ b/npm-wrapper/README.md
@@ -1,0 +1,100 @@
+# mcp-tap
+
+**The last MCP server you install by hand.**
+
+mcp-tap lives inside your AI assistant. Ask it to find, install, and configure
+any MCP server — by talking to it. No more editing JSON files. No more
+Googling environment variables.
+
+> This is a thin Node.js wrapper that delegates to the Python package
+> ([PyPI: mcp-tap](https://pypi.org/project/mcp-tap/)). It lets you use
+> `npx mcp-tap` if you prefer npm-style tooling.
+
+## Install
+
+### Claude Desktop
+
+Add to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "mcp-tap": {
+      "command": "npx",
+      "args": ["-y", "mcp-tap"]
+    }
+  }
+}
+```
+
+### Claude Code
+
+```bash
+claude mcp add mcp-tap -- npx -y mcp-tap
+```
+
+### Cursor
+
+Add to `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "mcp-tap": {
+      "command": "npx",
+      "args": ["-y", "mcp-tap"]
+    }
+  }
+}
+```
+
+### Windsurf
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "mcp-tap": {
+      "command": "npx",
+      "args": ["-y", "mcp-tap"]
+    }
+  }
+}
+```
+
+## How it works
+
+This wrapper resolves the Python runtime in order:
+
+1. **uvx** (preferred) — uv's tool runner, fast and isolated
+2. **pipx run** — common Python tool runner
+3. **python -m mcp_tap** — requires prior `pip install mcp-tap`
+
+## What can mcp-tap do?
+
+| You say | mcp-tap does |
+|---------|-------------|
+| "Scan my project" | Detects your tech stack, recommends MCP servers |
+| "Find me an MCP for PostgreSQL" | Searches the registry, compares options |
+| "Set it up" | Installs, configures, validates the connection |
+| "Are my servers working?" | Health-checks every server concurrently |
+| "Lock my MCP setup" | Creates `mcp-tap.lock` for reproducible configs |
+
+## 12 Tools
+
+`scan_project` · `search_servers` · `configure_server` · `test_connection` ·
+`check_health` · `inspect_server` · `list_installed` · `remove_server` ·
+`verify` · `restore` · `apply_stack`
+
+Plus automatic lockfile management on configure/remove.
+
+## Requirements
+
+- Python 3.11+ (via [uv](https://docs.astral.sh/uv/), pipx, or system Python)
+
+## Links
+
+- **GitHub**: https://github.com/felipestenzel/mcp-tap
+- **PyPI**: https://pypi.org/project/mcp-tap/
+- **License**: MIT

--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-tap",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant.",
   "keywords": [
     "mcp",
@@ -21,7 +21,7 @@
     "url": "https://github.com/felipestenzel/mcp-tap/issues"
   },
   "bin": {
-    "mcp-tap": "./bin/mcp-tap.js"
+    "mcp-tap": "bin/mcp-tap.js"
   },
   "files": [
     "bin/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-tap"
-version = "0.3.0"
+version = "0.3.1"
 description = "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Add `npm-wrapper/README.md` so the [npmjs.com page](https://www.npmjs.com/package/mcp-tap) shows install instructions instead of being empty
- Add `npx` install alternative to main README (Claude Desktop, Claude Code, Cursor, Windsurf)
- Update tools table from 7 → 12 tools (security gate, lockfile, stacks, auto-healing, tool conflicts, inspect, verify, restore, apply_stack)
- Bump version to 0.3.1 to test OIDC auto-publish end-to-end

## Test plan
- [x] 933 tests passing
- [ ] After merge: `gh release create v0.3.1` → verify both PyPI and npm auto-publish via OIDC
- [ ] Verify npmjs.com shows README content