### PR TITLE
Fix npm OIDC publishing: Node 24 for npm >= 11.5.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,8 +44,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
-          registry-url: "https://registry.npmjs.org"
+          node-version: "24"
 
       - name: Sync version from tag
         run: |


### PR DESCRIPTION
## Summary
- v0.3.1 publish confirmed PyPI OIDC works, but npm failed with `E404` / "Access token expired"
- Root cause: npm trusted publishing via OIDC requires **npm >= 11.5.1** (Node 24). We were using Node 22 (npm 10.x)
- Also removed `registry-url` from `setup-node` — it creates an `.npmrc` with `NODE_AUTH_TOKEN` placeholder that interferes with OIDC flow

## Test plan
- [ ] After merge: create v0.3.2 release and verify npm auto-publishes successfully
- [ ] Verify: `npm view mcp-tap version` returns 0.3.2

Sources: [npm trusted publishing docs](https://docs.npmjs.com/trusted-publishers/), [setup guide](https://remarkablemark.org/blog/2025/12/19/npm-trusted-publishing/)