### PR TITLE
Bump version to 0.5.1

### DIFF
--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-tap",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant.",
   "keywords": [
     "mcp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-tap"
-version = "0.5.0"
+version = "0.5.1"
 description = "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Patch release: improve agent narrative quality (no behavior changes to search logic).

**Changes shipped in v0.5.1:**
- Agent instructions now explicitly ban version numbers and internal architecture details from responses (no more "v0.5.0", "Smithery em paralelo", etc.)
- `search_servers` docstring updated to document `source`, `use_count`, `verified` return fields
- Agent instructions teach LLM to surface `verified` and `use_count` in recommendations

## Test plan
- [x] 1160 tests pass
- [x] Ruff clean