### PR TITLE
Disambiguate mcp-tap identity in agent instructions

### DIFF
--- a/src/mcp_tap/server.py
+++ b/src/mcp_tap/server.py
@@ -96,7 +96,10 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
 mcp = FastMCP(
     "mcp-tap",
     instructions=(
-        "mcp-tap discovers, installs, and configures MCP servers for the user. "
+        "mcp-tap is an MCP server that discovers, installs, and configures OTHER MCP servers. "
+        "It is NOT a network proxy, traffic inspector, or protocol debugger. "
+        "Think of it as a package manager for MCP servers: "
+        "scan a project, find the right servers, install them, verify they work. "
         "\n\n"
         "## When to use mcp-tap\n\n"
         "Invoke mcp-tap tools automatically — without waiting to be asked — whenever the user:\n"


### PR DESCRIPTION
## Problem

The name "mcp-tap" is ambiguous — LLMs interpret "tap" as a network tap/proxy/interceptor (like mitmproxy or Wireshark for MCP traffic). This caused Claude to describe mcp-tap as a "proxy/interceptor" and refuse to use its tools when the server wasn't explicitly recognized.

## Fix

Replaced the opening line of the agent instructions with an unambiguous description:

**Before:**
> mcp-tap discovers, installs, and configures MCP servers for the user.

**After:**
> mcp-tap is an MCP server that discovers, installs, and configures OTHER MCP servers. It is NOT a network proxy, traffic inspector, or protocol debugger. Think of it as a package manager for MCP servers: scan a project, find the right servers, install them, verify they work.

## Test plan
- [x] 1160 tests pass
- [x] Ruff clean