### PR TITLE
Bump version to 0.6.2

### DIFF
--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-tap",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant.",
   "keywords": [
     "mcp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-tap"
-version = "0.6.1"
+version = "0.6.2"
 description = "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bumps `pyproject.toml` and `npm-wrapper/package.json` to `0.6.2`

## What's in this release

- PR #62: HTTP config per-client — Claude Code gets native `{"type":"http","url":"..."}` while Cursor/Desktop/Windsurf get `mcp-remote` fallback in the same `configure_server` call