### PR TITLE
Bump version to 0.6.3

### DIFF
--- a/docs/issues/2026-02-23_release-v063.md
+++ b/docs/issues/2026-02-23_release-v063.md
@@ -1,0 +1,48 @@
+# Release v0.6.3
+
+- **Date**: 2026-02-23
+- **Status**: `in_progress`
+- **Branch**: `fix/2026-02-23-bump-v063`
+- **Priority**: `medium`
+
+## Problem
+
+PR #64 corrigiu um bug real em `verify` (falso `CONFIG_CHANGED` para servidores HTTP),
+mas a correção ainda não está disponível para usuários via `uvx mcp-tap@latest` e
+`npx mcp-tap`.
+
+## Context
+
+- Última versão publicada: `0.6.2`
+- Branch `main` já contém o merge de #64 (`f5c04df`)
+- Publicação é dirigida por tag (`v*`) via `.github/workflows/publish.yml`
+- Versões de PyPI (`pyproject.toml`) e npm wrapper (`npm-wrapper/package.json`) devem permanecer alinhadas
+
+## Root Cause
+
+Ainda não existe nova tag/release após o merge da correção de drift HTTP em `verify`.
+
+## Solution
+
+Bump de versão patch para `0.6.3` em Python + npm wrapper, via branch dedicada e PR.
+Após merge, criação da tag/release `v0.6.3` no GitHub para acionar o workflow de publish.
+
+## Files Changed
+
+- `pyproject.toml` — bump de versão `0.6.2` -> `0.6.3`
+- `npm-wrapper/package.json` — bump de versão `0.6.2` -> `0.6.3`
+- `docs/issues/2026-02-23_release-v063.md` — rastreio desta release
+
+## Verification
+
+- [ ] Tests pass: `pytest tests/`
+- [ ] Linter passes: `ruff check src/ tests/ && ruff format --check src/ tests/`
+- [ ] PR de bump mergeada em `main`
+- [ ] GitHub Release/tag `v0.6.3` criada
+- [ ] Publicação confirmada:
+  - `pip index versions mcp-tap`
+  - `npm view mcp-tap version`
+
+## Lessons Learned
+
+(Optional)

--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-tap",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant.",
   "keywords": [
     "mcp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-tap"
-version = "0.6.2"
+version = "0.6.3"
 description = "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump version from `0.6.2` to `0.6.3` in `pyproject.toml`
- bump npm wrapper version from `0.6.2` to `0.6.3` in `npm-wrapper/package.json`
- add release tracking issue doc `docs/issues/2026-02-23_release-v063.md`

## Why
PR #64 fixed a real `verify` HTTP drift false-positive. This patch release makes that fix available via PyPI/npm.

## Validation
- `uv run pytest tests/` (1238 passed)
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
