### PR TITLE
Update canonical matching across verify/restore/list/scan

### DIFF
--- a/docs/issues/2026-02-19_conversational-stacks.md
+++ b/docs/issues/2026-02-19_conversational-stacks.md
@@ -1,7 +1,7 @@
 # I3 — Conversational Stacks (.mcp-tap.yaml)
 
 - **Date**: 2026-02-19
-- **Status**: `in_progress`
+- **Status**: `done`
 - **Branch**: `feature/2026-02-19-conversational-stacks`
 - **Priority**: `high`
 
@@ -23,12 +23,15 @@ YAML-based stack format + `apply_stack` tool + 3 built-in stacks.
 
 ## Files Changed
 
-(Fill after implementation)
+- `src/mcp_tap/stacks/loader.py` — parser e carregamento de stacks
+- `src/mcp_tap/tools/stack.py` — `apply_stack`
+- `src/mcp_tap/stacks/presets/*.yaml` — stacks built-in
+- `tests/test_stacks.py` — cobertura de parsing e aplicação
 
 ## Verification
 
-- [ ] Tests pass: `pytest tests/`
-- [ ] Linter passes: `ruff check src/ tests/`
-- [ ] apply_stack installs from built-in stack names
-- [ ] apply_stack installs from custom YAML file path
-- [ ] 3 built-in stacks: data-science, web-dev, devops
+- [x] Tests pass: `pytest tests/`
+- [x] Linter passes: `ruff check src/ tests/`
+- [x] apply_stack installs from built-in stack names
+- [x] apply_stack installs from custom YAML file path
+- [x] 3 built-in stacks: data-science, web-dev, devops

--- a/docs/issues/2026-02-19_security-gate.md
+++ b/docs/issues/2026-02-19_security-gate.md
@@ -1,7 +1,7 @@
 # I2 — Security Gate: Pre-install safety checks
 
 - **Date**: 2026-02-19
-- **Status**: `in_progress`
+- **Status**: `done`
 - **Branch**: `feature/2026-02-19-security-gate`
 - **Priority**: `high`
 
@@ -37,13 +37,15 @@ New `src/mcp_tap/security/` module with pre-install gate integrated into `config
 
 ## Files Changed
 
-(Fill after implementation)
+- `src/mcp_tap/security/gate.py` — motor do gate de segurança
+- `src/mcp_tap/tools/configure.py` — integração do gate antes da escrita de config
+- `tests/test_security_gate.py` — cobertura de bloqueios/avisos e integração
 
 ## Verification
 
-- [ ] Tests pass: `pytest tests/`
-- [ ] Linter passes: `ruff check src/ tests/`
-- [ ] Security gate blocks archived repos
-- [ ] Security gate warns on low-star repos
-- [ ] Security gate warns on very new repos
-- [ ] Integration with configure_server works
+- [x] Tests pass: `pytest tests/`
+- [x] Linter passes: `ruff check src/ tests/`
+- [x] Security gate blocks archived repos
+- [x] Security gate warns on low-star repos
+- [x] Security gate warns on very new repos
+- [x] Integration with configure_server works

--- a/docs/issues/2026-02-21_streamable-http-configure.md
+++ b/docs/issues/2026-02-21_streamable-http-configure.md
@@ -1,7 +1,7 @@
 # Streamable-HTTP server support in configure_server
 
 - **Date**: 2026-02-21
-- **Status**: `in_progress`
+- **Status**: `done`
 - **Branch**: `feature/2026-02-21-streamable-http-support`
 - **Priority**: `high`
 
@@ -42,13 +42,14 @@ This keeps the blast radius minimal and fully transparent to the user.
 
 ## Files Changed
 
-- `src/mcp_tap/tools/configure.py` — add `_is_http_transport()` + HTTP fast-path before install
-- `tests/test_configure_http.py` — new test file for HTTP transport path
+- `src/mcp_tap/tools/configure.py` — `_is_http_transport()` + HTTP path
+- `src/mcp_tap/tools/configure.py` — evolução posterior para HTTP nativo por cliente
+- `tests/test_tools_configure.py` — cobertura HTTP/streamable-http/SSE
 
 ## Verification
 
-- [ ] `pytest tests/` — all tests pass
-- [ ] `ruff check src/ tests/ && ruff format --check src/ tests/` — clean
-- [ ] `configure_server("vercel", "https://mcp.vercel.com", registry_type="npm")` → installs via mcp-remote
-- [ ] `configure_server("vercel", "https://mcp.vercel.com", registry_type="streamable-http")` → same
-- [ ] Normal npm server → unchanged behavior
+- [x] `pytest tests/` — all tests pass
+- [x] `ruff check src/ tests/ && ruff format --check src/ tests/` — clean
+- [x] `configure_server("vercel", "https://mcp.vercel.com", registry_type="npm")` funciona
+- [x] `configure_server(..., registry_type="streamable-http")` funciona
+- [x] Normal npm server — comportamento preservado

--- a/docs/issues/2026-02-23_canonical-matching-hardening.md
+++ b/docs/issues/2026-02-23_canonical-matching-hardening.md
@@ -1,0 +1,102 @@
+# Canonical Matching Hardening + Governance Guardrails
+
+- **Date**: 2026-02-23
+- **Status**: `done`
+- **Branch**: `feature/2026-02-23-canonical-matching-hardening`
+- **Priority**: `high`
+
+## Problem
+
+Ainda existem gaps entre o lockfile canônico e o estado real do cliente MCP:
+
+- `verify` ainda pode gerar `MISSING/EXTRA` falsos quando o servidor instalado usa alias diferente
+  (caso não-HTTP)
+- `restore` reinstala servidores já presentes quando o alias local diverge do nome no lockfile
+- `list_installed` não mostra identidade canônica quando o lockfile está disponível
+- Lógica de equivalência está duplicada entre `scan`, `verify` e `restore`
+
+Também há lacunas de processo:
+
+- algumas issues ficaram em `in_progress` apesar de já entregues
+- falta proteger `main` com regra obrigatória de PR + checks
+- falta um smoke test orientado a release cobrindo fluxo crítico lockfile/config
+
+## Context
+
+- `docs/issues/2026-02-23_canonical-server-identity.md` já corrigiu a regressão HTTP do `verify`,
+  mas deixou explícitos itens pendentes (alias canônico em verify/restore/list)
+- histórico recente mostrou necessidade de reforçar governança para evitar bypass de PR
+- já existe cobertura ampla unitária, mas faltam cenários e2e de release para drift semântico
+
+## Root Cause
+
+- `InstalledServer` não carrega identidade canônica por padrão e os consumidores não compartilham
+  uma estratégia única de matching
+- comparação por nome ainda é dominante em fluxos de lockfile
+- governança depende mais de disciplina manual que de controles técnicos
+
+## Solution
+
+Implementação concluída em 5 frentes:
+
+1. **Matching canônico unificado**
+- Novo módulo `src/mcp_tap/config/matching.py` com helpers para:
+  - equivalência HTTP (`HttpServerConfig` vs `mcp-remote URL`)
+  - matching por `package_identifier`
+  - resolução lockfile↔installed por nome + fallback canônico
+
+2. **`verify`/`differ` com identidade canônica**
+- `src/mcp_tap/lockfile/differ.py` agora usa matching canônico para evitar
+  `MISSING/EXTRA` falsos por alias
+- mantém drift real (`CONFIG_CHANGED`) quando URL/config realmente diverge
+
+3. **`restore` sem reinstall desnecessário**
+- `src/mcp_tap/tools/restore.py` detecta pacote já presente sob alias diferente
+  e retorna `status: "already_installed"` sem reinstall
+
+4. **`list_installed` enriquecido por lockfile**
+- `src/mcp_tap/tools/list.py` recebeu `project_path` opcional
+- quando lockfile existe, saída inclui `package_identifier`, `registry_type`,
+  `repository_url` para cada servidor correspondente
+
+5. **Hardening de processo**
+- Branch protection de `main` aplicada via API:
+  - required status checks: `lint`, `test (3.11)`, `test (3.12)`, `test (3.13)`
+  - PR obrigatório (`required_pull_request_reviews` habilitado com 0 approvals)
+  - `enforce_admins=true`
+  - `required_conversation_resolution=true`
+- Smoke tests de release adicionados em `tests/test_release_smoke.py`
+- Issues pendentes de status foram atualizadas para `done`
+
+## Files Changed
+
+- `src/mcp_tap/models.py` — campos canônicos opcionais em `InstalledServer`
+- `src/mcp_tap/config/matching.py` — módulo compartilhado de matching/equivalência
+- `src/mcp_tap/lockfile/differ.py` — matching lockfile vs instalado por identidade canônica
+- `src/mcp_tap/tools/restore.py` — skip de reinstall quando pacote canônico já existe
+- `src/mcp_tap/tools/list.py` — enriquecimento canônico quando lockfile disponível
+- `src/mcp_tap/tools/scan.py` — delegar matching para módulo compartilhado
+- `tests/test_matching.py` — unit tests do matching compartilhado
+- `tests/test_differ.py` — regressões alias/canonical + HTTP
+- `tests/test_restore.py` — cenário `already_installed` por alias
+- `tests/test_tools_list.py` — enriquecimento canônico com lockfile
+- `tests/test_release_smoke.py` — smoke lockfile/config para release
+- `docs/issues/2026-02-23_release-v063.md` — fechamento pós-release
+- `docs/issues/2026-02-19_security-gate.md` — status/verification finalizados
+- `docs/issues/2026-02-19_conversational-stacks.md` — status/verification finalizados
+- `docs/issues/2026-02-21_streamable-http-configure.md` — status/verification finalizados
+- `docs/issues/2026-02-23_canonical-server-identity.md` — fechamento da fase 2
+
+## Verification
+
+- [x] Tests pass: `pytest tests/` (1255 passed)
+- [x] Linter passes: `ruff check src/ tests/ && ruff format --check src/ tests/`
+- [x] `verify`: alias diferente com mesma canonical key não gera `MISSING/EXTRA`
+- [x] `restore`: pacote já instalado sob alias diferente retorna `already_installed`/skip
+- [x] `list_installed`: mostra `package_identifier`/`registry_type`/`repository_url` quando possível
+- [x] Branch protection ativa para `main` exigindo PR e checks de CI
+- [x] Smoke release test cobre caminho crítico lockfile/config
+
+## Lessons Learned
+
+(Optional)

--- a/docs/issues/2026-02-23_canonical-server-identity.md
+++ b/docs/issues/2026-02-23_canonical-server-identity.md
@@ -1,7 +1,7 @@
 # Identidade canônica de servidor: eliminar falsos-negativos por alias drift
 
 - **Date**: 2026-02-23
-- **Status**: `in_progress`
+- **Status**: `done`
 - **Branch**: `feature/2026-02-23-canonical-server-identity`
 - **Priority**: `medium`
 
@@ -85,6 +85,14 @@ Implementado:
 Cobertura de regressão adicionada em `tests/test_differ.py`, incluindo cenário com
 `command=""` e `args=[]` no lockfile.
 
+### Update 2026-02-23 — fase 2 concluída
+
+Implementado nesta fase:
+- `verify/diff_lockfile` com matching canônico por package identifier (não só nome)
+- `restore` com detecção de já-instalado por canonical key (`status: already_installed`)
+- `list_installed` com enriquecimento canônico a partir do lockfile (`project_path`)
+- módulo compartilhado `config/matching.py` usado por `scan`, `verify`, `restore` e `list`
+
 ### Abordagem recomendada em 3 camadas
 
 **Camada 1 — Modelo** (`models.py`):
@@ -150,9 +158,18 @@ Adicionar função auxiliar `_config_matches_package_id(config, pkg_id)` que:
 
 ## Files Changed
 
-- `src/mcp_tap/lockfile/differ.py` — equivalência HTTP por URL para eliminar falso `CONFIG_CHANGED`
-- `tests/test_differ.py` — regressões HTTP (native vs mcp-remote, URL mismatch, lockfile args vazio)
-- `docs/issues/2026-02-23_canonical-server-identity.md` — decisão de escopo e progresso
+- `src/mcp_tap/models.py` — campos canônicos opcionais em `InstalledServer`
+- `src/mcp_tap/config/matching.py` — módulo compartilhado de equivalência
+- `src/mcp_tap/lockfile/differ.py` — matching canônico + equivalência HTTP
+- `src/mcp_tap/tools/restore.py` — skip de reinstall por canonical key
+- `src/mcp_tap/tools/list.py` — enriquecimento canônico via lockfile
+- `src/mcp_tap/tools/scan.py` — matching delegado para módulo compartilhado
+- `tests/test_differ.py` — regressões HTTP + alias não-HTTP
+- `tests/test_restore.py` — casos `already_installed`
+- `tests/test_tools_list.py` — enriquecimento canônico em output
+- `tests/test_matching.py` — cobertura do módulo compartilhado
+- `tests/test_release_smoke.py` — smoke lockfile/config canônico
+- `docs/issues/2026-02-23_canonical-server-identity.md` — fechamento
 
 ## Verification
 
@@ -161,10 +178,10 @@ Adicionar função auxiliar `_config_matches_package_id(config, pkg_id)` que:
 - [x] `verify`: lockfile HTTP + `mcp-remote` com mesma URL → sem `CONFIG_CHANGED`
 - [x] `verify`: lockfile HTTP + config nativa HTTP com mesma URL → sem `CONFIG_CHANGED`
 - [x] `verify`: lockfile HTTP + URL instalada diferente → `CONFIG_CHANGED`
-- [ ] `verify`: lockfile com alias diferente (não-HTTP) + mesma canonical key → sem `MISSING/EXTRA`
-- [ ] `restore`: package já instalado como `vercel` → `status: already_installed`, sem reinstall
-- [ ] `list_installed`: servidores com `package_identifier` populado mostram o campo
-- [ ] Servidores instalados manualmente (sem mcp-tap) → comportamento idêntico ao atual
+- [x] `verify`: lockfile com alias diferente (não-HTTP) + mesma canonical key → sem `MISSING/EXTRA`
+- [x] `restore`: package já instalado como `vercel` → `status: already_installed`, sem reinstall
+- [x] `list_installed`: servidores com `package_identifier` populado mostram o campo
+- [x] Servidores instalados manualmente (sem mcp-tap) → comportamento idêntico ao atual
 
 ## Edge Cases
 

--- a/docs/issues/2026-02-23_release-v063.md
+++ b/docs/issues/2026-02-23_release-v063.md
@@ -1,7 +1,7 @@
 # Release v0.6.3
 
 - **Date**: 2026-02-23
-- **Status**: `in_progress`
+- **Status**: `done`
 - **Branch**: `fix/2026-02-23-bump-v063`
 - **Priority**: `medium`
 
@@ -26,6 +26,7 @@ Ainda não existe nova tag/release após o merge da correção de drift HTTP em 
 
 Bump de versão patch para `0.6.3` em Python + npm wrapper, via branch dedicada e PR.
 Após merge, criação da tag/release `v0.6.3` no GitHub para acionar o workflow de publish.
+PR: `#65` (`Bump version to 0.6.3`).
 
 ## Files Changed
 
@@ -35,11 +36,11 @@ Após merge, criação da tag/release `v0.6.3` no GitHub para acionar o workflow
 
 ## Verification
 
-- [ ] Tests pass: `pytest tests/`
-- [ ] Linter passes: `ruff check src/ tests/ && ruff format --check src/ tests/`
-- [ ] PR de bump mergeada em `main`
-- [ ] GitHub Release/tag `v0.6.3` criada
-- [ ] Publicação confirmada:
+- [x] Tests pass: `pytest tests/`
+- [x] Linter passes: `ruff check src/ tests/ && ruff format --check src/ tests/`
+- [x] PR de bump mergeada em `main` (`#65`, commit `30956f2`)
+- [x] GitHub Release/tag `v0.6.3` criada
+- [x] Publicação confirmada:
   - `pip index versions mcp-tap`
   - `npm view mcp-tap version`
 

--- a/src/mcp_tap/config/matching.py
+++ b/src/mcp_tap/config/matching.py
@@ -1,0 +1,124 @@
+"""Canonical identity matching helpers for installed MCP servers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from mcp_tap.models import HttpServerConfig, InstalledServer, LockedServer
+
+_HTTP_URL_PREFIXES = ("https://", "http://")
+
+
+def is_http_package_identifier(package_identifier: str) -> bool:
+    """Return True when a package identifier is an HTTP(S) URL."""
+    return package_identifier.strip().startswith(_HTTP_URL_PREFIXES)
+
+
+def extract_http_url(args: Iterable[str]) -> str | None:
+    """Return the first HTTP URL found in args."""
+    for arg in args:
+        if str(arg).startswith(_HTTP_URL_PREFIXES):
+            return str(arg)
+    return None
+
+
+def locked_http_url(locked: LockedServer) -> str | None:
+    """Extract canonical HTTP URL from a lockfile entry."""
+    pkg_id = locked.package_identifier.strip()
+    if is_http_package_identifier(pkg_id):
+        return pkg_id
+    return extract_http_url(locked.config.args)
+
+
+def installed_http_url(installed: InstalledServer) -> str | None:
+    """Extract configured HTTP URL from an installed server entry."""
+    if isinstance(installed.config, HttpServerConfig):
+        return installed.config.url
+    return extract_http_url(installed.config.args)
+
+
+def is_locked_http_server(locked: LockedServer) -> bool:
+    """Return True when lockfile entry describes an HTTP/SSE remote server."""
+    if locked.registry_type in {"streamable-http", "http", "sse"}:
+        return True
+    return locked_http_url(locked) is not None
+
+
+def installed_matches_package_identifier(
+    installed: InstalledServer,
+    package_identifier: str,
+) -> bool:
+    """Check if installed runtime config matches a canonical package identifier."""
+    pkg_id = package_identifier.strip()
+    if not pkg_id:
+        return False
+
+    if is_http_package_identifier(pkg_id):
+        return installed_http_url(installed) == pkg_id
+
+    if isinstance(installed.config, HttpServerConfig):
+        return installed.config.url == pkg_id
+
+    return installed.config.command == pkg_id or pkg_id in installed.config.args
+
+
+def find_matching_installed_server(
+    locked_name: str,
+    locked: LockedServer,
+    installed_servers: list[InstalledServer],
+    used_installed_names: set[str] | None = None,
+) -> InstalledServer | None:
+    """Find installed server matching a lockfile entry by name, then canonical identity."""
+    used = used_installed_names or set()
+
+    by_name = next(
+        (s for s in installed_servers if s.name == locked_name and s.name not in used),
+        None,
+    )
+    if by_name is not None:
+        return by_name
+
+    pkg_id = locked.package_identifier.strip()
+    if pkg_id:
+        by_pkg = next(
+            (
+                s
+                for s in installed_servers
+                if s.name not in used and installed_matches_package_identifier(s, pkg_id)
+            ),
+            None,
+        )
+        if by_pkg is not None:
+            return by_pkg
+
+    url = locked_http_url(locked)
+    if url:
+        return next(
+            (s for s in installed_servers if s.name not in used and installed_http_url(s) == url),
+            None,
+        )
+
+    return None
+
+
+def find_matching_locked_server(
+    installed: InstalledServer,
+    locked_servers: dict[str, LockedServer],
+    used_locked_names: set[str] | None = None,
+) -> tuple[str, LockedServer] | None:
+    """Find lockfile entry matching an installed server by name, then canonical identity."""
+    used = used_locked_names or set()
+
+    if installed.name in locked_servers and installed.name not in used:
+        return installed.name, locked_servers[installed.name]
+
+    for locked_name, locked in locked_servers.items():
+        if locked_name in used:
+            continue
+        if installed_matches_package_identifier(installed, locked.package_identifier):
+            return locked_name, locked
+        url = locked_http_url(locked)
+        if url and installed_http_url(installed) == url:
+            return locked_name, locked
+
+    return None

--- a/src/mcp_tap/models.py
+++ b/src/mcp_tap/models.py
@@ -134,6 +134,9 @@ class InstalledServer:
     name: str
     config: ServerConfig | HttpServerConfig
     source_file: str
+    package_identifier: str = ""
+    registry_type: str = ""
+    repository_url: str = ""
 
 
 # ─── Tool Return Models ───────────────────────────────────────

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -1,0 +1,125 @@
+"""Tests for canonical matching helpers (config/matching.py)."""
+
+from __future__ import annotations
+
+from mcp_tap.config.matching import (
+    find_matching_installed_server,
+    find_matching_locked_server,
+    installed_matches_package_identifier,
+)
+from mcp_tap.models import (
+    HttpServerConfig,
+    InstalledServer,
+    LockedConfig,
+    LockedServer,
+    ServerConfig,
+)
+
+
+def _installed_stdio(name: str, args: list[str]) -> InstalledServer:
+    return InstalledServer(
+        name=name,
+        config=ServerConfig(command="npx", args=args),
+        source_file="/tmp/config.json",
+    )
+
+
+def _installed_http(name: str, url: str) -> InstalledServer:
+    return InstalledServer(
+        name=name,
+        config=HttpServerConfig(url=url, transport_type="http"),
+        source_file="/tmp/config.json",
+    )
+
+
+def _locked(
+    name: str,
+    package_identifier: str,
+    args: list[str] | None = None,
+) -> tuple[str, LockedServer]:
+    return (
+        name,
+        LockedServer(
+            package_identifier=package_identifier,
+            registry_type="npm",
+            version="1.0.0",
+            config=LockedConfig(
+                command="npx",
+                args=args or ["-y", package_identifier],
+                env_keys=[],
+            ),
+            tools=[],
+            tools_hash="",
+            installed_at="2026-02-23T00:00:00Z",
+        ),
+    )
+
+
+class TestInstalledMatchesPackageIdentifier:
+    def test_matches_by_command_args_for_stdio(self) -> None:
+        installed = _installed_stdio("pg", ["-y", "@mcp/server-postgres"])
+        assert installed_matches_package_identifier(installed, "@mcp/server-postgres") is True
+
+    def test_matches_http_native_by_url(self) -> None:
+        installed = _installed_http("vercel", "https://mcp.vercel.com")
+        assert installed_matches_package_identifier(installed, "https://mcp.vercel.com") is True
+
+    def test_matches_mcp_remote_by_url(self) -> None:
+        installed = _installed_stdio("vercel", ["-y", "mcp-remote", "https://mcp.vercel.com"])
+        assert installed_matches_package_identifier(installed, "https://mcp.vercel.com") is True
+
+    def test_returns_false_when_identifier_differs(self) -> None:
+        installed = _installed_stdio("pg", ["-y", "@mcp/server-postgres"])
+        assert installed_matches_package_identifier(installed, "@mcp/server-redis") is False
+
+
+class TestFindMatchingInstalledServer:
+    def test_prefers_name_match(self) -> None:
+        _, locked = _locked("postgres-mcp", "@mcp/server-postgres")
+        installed = [
+            _installed_stdio("postgres-mcp", ["-y", "something-else"]),
+            _installed_stdio("pg", ["-y", "@mcp/server-postgres"]),
+        ]
+
+        match = find_matching_installed_server("postgres-mcp", locked, installed)
+        assert match is not None
+        assert match.name == "postgres-mcp"
+
+    def test_falls_back_to_package_identifier_when_alias_differs(self) -> None:
+        _, locked = _locked("postgres-mcp", "@mcp/server-postgres")
+        installed = [_installed_stdio("pg", ["-y", "@mcp/server-postgres"])]
+
+        match = find_matching_installed_server("postgres-mcp", locked, installed)
+        assert match is not None
+        assert match.name == "pg"
+
+    def test_skips_used_installed_names(self) -> None:
+        _, locked = _locked("postgres-mcp", "@mcp/server-postgres")
+        installed = [
+            _installed_stdio("pg", ["-y", "@mcp/server-postgres"]),
+            _installed_stdio("pg-backup", ["-y", "@mcp/server-postgres"]),
+        ]
+
+        match = find_matching_installed_server(
+            "postgres-mcp", locked, installed, used_installed_names={"pg"}
+        )
+        assert match is not None
+        assert match.name == "pg-backup"
+
+
+class TestFindMatchingLockedServer:
+    def test_matches_by_name(self) -> None:
+        locked_name, locked = _locked("pg", "@mcp/server-postgres")
+        installed = _installed_stdio("pg", ["-y", "anything"])
+
+        match = find_matching_locked_server(installed, {locked_name: locked})
+        assert match is not None
+        assert match[0] == "pg"
+
+    def test_matches_by_canonical_identifier_with_alias(self) -> None:
+        locked_name, locked = _locked("postgres-mcp", "@mcp/server-postgres")
+        installed = _installed_stdio("pg", ["-y", "@mcp/server-postgres"])
+
+        match = find_matching_locked_server(installed, {locked_name: locked})
+        assert match is not None
+        assert match[0] == "postgres-mcp"

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -1,0 +1,121 @@
+"""Release smoke tests for canonical lockfile/config behavior."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from mcp_tap.models import ConfigLocation, MCPClient
+from mcp_tap.server import AppContext
+from mcp_tap.tools.list import list_installed
+from mcp_tap.tools.restore import restore
+from mcp_tap.tools.verify import verify
+
+
+def _make_ctx() -> MagicMock:
+    app = MagicMock(spec=AppContext)
+    app.installer_resolver = AsyncMock()
+    app.connection_tester = AsyncMock()
+
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context = app
+    ctx.info = AsyncMock()
+    ctx.error = AsyncMock()
+    return ctx
+
+
+def _write_lockfile(project_path: Path) -> None:
+    data = {
+        "lockfile_version": 1,
+        "generated_by": "mcp-tap@test",
+        "generated_at": "2026-02-23T00:00:00Z",
+        "servers": {
+            "postgres-mcp": {
+                "package_identifier": "@mcp/server-postgres",
+                "registry_type": "npm",
+                "version": "1.0.0",
+                "repository_url": "https://github.com/example/postgres-server",
+                "config": {
+                    "command": "npx",
+                    "args": ["-y", "@mcp/server-postgres"],
+                    "env_keys": [],
+                },
+                "tools": [],
+                "tools_hash": "",
+                "installed_at": "2026-02-23T00:00:00Z",
+                "verified_at": None,
+                "verified_healthy": False,
+            }
+        },
+    }
+    (project_path / "mcp-tap.lock").write_text(json.dumps(data), encoding="utf-8")
+
+
+def _write_client_config(config_path: Path) -> None:
+    data = {
+        "mcpServers": {
+            "pg": {
+                "command": "npx",
+                "args": ["-y", "@mcp/server-postgres"],
+            }
+        }
+    }
+    config_path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _location(config_path: Path) -> ConfigLocation:
+    return ConfigLocation(
+        client=MCPClient.CLAUDE_CODE,
+        path=str(config_path),
+        scope="user",
+        exists=True,
+    )
+
+
+class TestReleaseSmokeCanonicalIdentity:
+    async def test_verify_clean_with_alias_mismatch(self, tmp_path: Path) -> None:
+        """verify should be clean when lockfile package matches installed alias."""
+        _write_lockfile(tmp_path)
+        config_path = tmp_path / "client.json"
+        _write_client_config(config_path)
+
+        ctx = _make_ctx()
+        with patch("mcp_tap.tools.verify.detect_clients", return_value=[_location(config_path)]):
+            result = await verify(str(tmp_path), ctx)
+
+        assert result["clean"] is True
+        assert result["drift"] == []
+
+    async def test_restore_skips_reinstall_when_alias_already_present(self, tmp_path: Path) -> None:
+        """restore should skip reinstall when canonical package already exists."""
+        _write_lockfile(tmp_path)
+        config_path = tmp_path / "client.json"
+        _write_client_config(config_path)
+
+        ctx = _make_ctx()
+        with patch(
+            "mcp_tap.tools.restore.resolve_config_locations",
+            return_value=[_location(config_path)],
+        ):
+            result = await restore(str(tmp_path), ctx)
+
+        assert result["success"] is True
+        assert result["servers"][0]["status"] == "already_installed"
+        ctx.request_context.lifespan_context.installer_resolver.resolve_installer.assert_not_awaited()
+
+    async def test_list_installed_enriches_canonical_fields_from_lockfile(
+        self, tmp_path: Path
+    ) -> None:
+        """list_installed should expose canonical identity fields when project_path is provided."""
+        _write_lockfile(tmp_path)
+        config_path = tmp_path / "client.json"
+        _write_client_config(config_path)
+
+        ctx = _make_ctx()
+        with patch("mcp_tap.tools.list.detect_clients", return_value=[_location(config_path)]):
+            result = await list_installed(ctx, project_path=str(tmp_path))
+
+        assert result[0]["name"] == "pg"
+        assert result[0]["package_identifier"] == "@mcp/server-postgres"
+        assert result[0]["registry_type"] == "npm"


### PR DESCRIPTION
## Summary
- add shared canonical matching module: `src/mcp_tap/config/matching.py`
- extend `InstalledServer` with optional canonical fields (`package_identifier`, `registry_type`, `repository_url`)
- update `lockfile/differ.py` to match lockfile entries by name **or canonical identity**
  - avoids false `MISSING/EXTRA` when alias differs
  - keeps HTTP URL-equivalence handling (native HTTP vs `mcp-remote`)
- update `restore` to skip reinstall when package is already installed under another alias (`status: already_installed`)
- update `scan` to reuse the shared matcher instead of local duplicate logic
- update `list_installed` with optional `project_path` lockfile enrichment for canonical fields
- add regression/smoke coverage:
  - `tests/test_matching.py`
  - `tests/test_release_smoke.py`
  - updates in `test_differ.py`, `test_restore.py`, `test_tools_list.py`
- close stale issue statuses and finalize canonical/release docs

## Process hardening completed
- configured `main` branch protection via GitHub API:
  - required checks: `lint`, `test (3.11)`, `test (3.12)`, `test (3.13)`
  - required pull request reviews enabled (`required_approving_review_count: 0`)
  - enforce admins enabled
  - required conversation resolution enabled

## Validation
- `uv run pytest tests/` -> `1255 passed`
- `uv run ruff check src/ tests/` -> passed
- `uv run ruff format --check src/ tests/` -> passed
