### PR TITLE
Bump version to 0.6.4

### DIFF
--- a/docs/issues/2026-02-24_72_release-v064.md
+++ b/docs/issues/2026-02-24_72_release-v064.md
@@ -1,0 +1,40 @@
+# Release v0.6.4
+
+- **Date**: 2026-02-24
+- **Issue**: #72
+- **Status**: `in_progress`
+- **Branch**: `fix/2026-02-24-release-v064`
+- **Priority**: `medium`
+
+## Problem
+
+Main already includes merged changes from PR #68, but users still install `0.6.3` from PyPI/npm.
+
+## Context
+
+- Latest released version: `0.6.3`
+- Main contains recommendation quality gate, deterministic scoring, and client-matrix E2E tests
+- Publish is triggered by GitHub release tag (`v*`)
+
+## Root Cause
+
+No new version bump/tag exists after merging PR #68.
+
+## Solution
+
+(Fill after implementation)
+
+## Files Changed
+
+- `docs/issues/2026-02-24_72_release-v064.md` — release tracking issue doc
+
+## Verification
+
+- [ ] Version bumped in Python + npm wrapper
+- [ ] PR merged to main
+- [ ] GitHub release/tag `v0.6.4` created
+- [ ] PyPI and npm show `0.6.4`
+
+## Lessons Learned
+
+(Optional)

--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-tap",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant.",
   "keywords": [
     "mcp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-tap"
-version = "0.6.3"
+version = "0.6.4"
 description = "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump Python package version: `0.6.3 -> 0.6.4`
- bump npm wrapper version: `0.6.3 -> 0.6.4`
- add release tracking issue doc `#72`

## Files
- `pyproject.toml`
- `npm-wrapper/package.json`
- `docs/issues/2026-02-24_72_release-v064.md`

## Validation
- `uv run pytest tests/ -q` (1268 passed)
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`

Closes #72
