### PR TITLE
Bump version to 0.6.5

### DIFF
--- a/docs/issues/2026-02-24_77_release-v065.md
+++ b/docs/issues/2026-02-24_77_release-v065.md
@@ -1,0 +1,40 @@
+# Release v0.6.5
+
+- **Date**: 2026-02-24
+- **Issue**: #77
+- **Status**: `in_progress`
+- **Branch**: `fix/2026-02-24-release-v065`
+- **Priority**: `medium`
+
+## Problem
+
+Main includes changes after `v0.6.4`, but registries still expose `0.6.4` as latest.
+
+## Context
+
+- Latest published release before this work: `v0.6.4`
+- New merged work includes issue tracking improvements around semantic intent rerank planning
+- Publish flow is tag-driven via GitHub Release (`v*`)
+
+## Root Cause
+
+No version bump/tag was created after the latest merge.
+
+## Solution
+
+(Fill after implementation)
+
+## Files Changed
+
+- `docs/issues/2026-02-24_77_release-v065.md` — release tracking issue doc
+
+## Verification
+
+- [ ] Version bumped in Python + npm wrapper
+- [ ] Release PR merged to main
+- [ ] GitHub release/tag `v0.6.5` created
+- [ ] PyPI and npm show `0.6.5`
+
+## Lessons Learned
+
+(Optional)

--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-tap",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant.",
   "keywords": [
     "mcp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-tap"
-version = "0.6.4"
+version = "0.6.5"
 description = "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump package version `0.6.4 -> 0.6.5` (Python + npm wrapper)
- add release tracking doc for issue #77

## Files
- `pyproject.toml`
- `npm-wrapper/package.json`
- `docs/issues/2026-02-24_77_release-v065.md`

## Validation
- `uv run pytest tests/ -q` (1268 passed)
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`

Closes #77
