### PR TITLE
Bump version to 0.6.6

### DIFF
--- a/docs/issues/2026-02-24_83_release-v066.md
+++ b/docs/issues/2026-02-24_83_release-v066.md
@@ -1,0 +1,42 @@
+# Release v0.6.6
+
+- **Date**: 2026-02-24
+- **Issue**: #83
+- **Status**: `open`
+- **Branch**: `feature/2026-02-24-release-v066`
+- **Priority**: `high`
+
+## Problem
+
+The repository has merged feature work in PR #80 and PR #82, but no published release bundles
+these changes yet.
+
+## Context
+
+- PR #80 (semantic intent rerank) is merged into main.
+- PR #82 (official Python 3.14 support in CI/metadata) is merged into main.
+- Latest published version is v0.6.5.
+
+## Root Cause
+
+Release cut/publish steps were not executed after merge completion.
+
+## Solution
+
+(Fill after implementation)
+
+## Files Changed
+
+- `docs/issues/2026-02-24_83_release-v066.md` — issue tracking doc
+
+## Verification
+
+- [ ] Version bump committed and merged (`0.6.6`)
+- [ ] GitHub Release `v0.6.6` created
+- [ ] PyPI shows `mcp-tap==0.6.6`
+- [ ] npm shows `mcp-tap@0.6.6`
+- [ ] Practical smoke with `uvx mcp-tap@0.6.6` passes
+
+## Lessons Learned
+
+(Optional)

--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-tap",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant.",
   "keywords": [
     "mcp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-tap"
-version = "0.6.5"
+version = "0.6.6"
 description = "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump release version to `0.6.6` in Python and npm package metadata
- add release issue doc `docs/issues/2026-02-24_83_release-v066.md`

## Validation
- `uv run ruff check src/ tests/`
- `uv run pytest tests/ -q`

Closes #83
