### PR TITLE
Add issue docs for next quality backlog (#86-#89)

### DIFF
--- a/docs/issues/2026-02-24_86_semantic-precision-off-intent-suppression.md
+++ b/docs/issues/2026-02-24_86_semantic-precision-off-intent-suppression.md
@@ -1,0 +1,91 @@
+# Semantic Precision V2: Off-Intent Suppression in `search_servers`
+
+- **Date**: 2026-02-24
+- **Issue**: #86
+- **Status**: `open`
+- **Branch**: `feature/2026-02-24-quality-gap-issues`
+- **Priority**: `critical`
+
+## Problem
+
+`search_servers` improved semantic ranking in v0.6.6, but practical smoke still shows
+off-intent noise in top-k for broad intent queries.
+
+Observed output (real smoke post-release):
+- Query: `error monitoring`
+- Relevant providers appeared: `sentry`, `newrelic`, `datadog`
+- But an off-intent candidate (`Supabase`) still appeared in top-2
+
+For discovery UX, top-3 must be intent-clean. Partial improvement is not enough.
+
+## Context
+
+- Module affected: `src/mcp_tap/tools/search.py`
+- Current state already includes:
+  - query expansion
+  - intent score (`intent_match_score`, `intent_match_reason`)
+  - deterministic composite rerank
+- Remaining gap appears when popularity/provenance + partial lexical overlap can still outrank
+  weakly related generic tools.
+
+## Root Cause
+
+(Working hypothesis; confirm in implementation)
+
+1. Retrieval stage is recall-oriented and intentionally broad, but precision cleanup is incomplete.
+2. Current ranking has strong positive intent signals, but lacks a clear negative off-intent prior.
+3. Candidate suppression/gating before final top-k is insufficient for broad semantic queries.
+
+## Solution
+
+Implement **Semantic Precision V2** with two-stage ranking:
+
+### 1) Stage A: Recall-Oriented Candidate Retrieval
+- Keep current query expansion (intent + provider hints)
+- Keep broad candidate pool (do not over-prune retrieval)
+
+### 2) Stage B: Precision-Oriented Intent Suppression
+- Add explicit negative evidence model per intent family (off-intent priors)
+- Add intent-confidence thresholding before final top-k
+- Demote low-confidence/off-intent candidates below high-confidence intent matches
+- Preserve deterministic ordering rules
+
+### 3) Optional Debug Signals (if API-safe)
+- `intent_confidence`
+- `intent_positive_signals`
+- `intent_negative_signals`
+- `intent_gate_applied`
+
+### 4) Benchmark + Regression Coverage
+- Add broad-intent fixtures to recommendation benchmark
+- Add unit regression tests for off-intent suppression in `tests/test_tools_search.py`
+- Add release smoke assertion for target query class (`error monitoring`)
+
+## Files Changed
+
+- `src/mcp_tap/tools/search.py` — intent suppression/gating logic
+- `tests/test_tools_search.py` — regression tests for broad-query precision
+- `src/mcp_tap/benchmark/recommendation_dataset_v1.json` — broad-intent fixtures
+- `tests/test_recommendation_benchmark.py` — benchmark assertions for semantic precision
+- `docs/issues/2026-02-24_86_semantic-precision-off-intent-suppression.md` — issue tracking
+
+## Verification
+
+- [ ] Tests pass: `pytest tests/`
+- [ ] Linter passes: `ruff check src/ tests/`
+- [ ] Broad intent query top-3 has only intent-relevant candidates
+- [ ] Deterministic output preserved for identical input
+- [ ] No regression in narrow/exact query behavior
+
+## Lessons Learned
+
+(Complete after delivery)
+
+## References
+
+- OpenSearch hybrid ranking optimization:
+  - https://docs.opensearch.org/latest/search-plugins/search-relevance/optimize-hybrid-search/
+- OpenSearch reciprocal rank fusion (RRF):
+  - https://opensearch.org/blog/introducing-reciprocal-rank-fusion-hybrid-search/
+- Azure semantic ranking (two-stage concept):
+  - https://learn.microsoft.com/en-us/azure/search/semantic-ranking

--- a/docs/issues/2026-02-24_87_runtime-version-single-source-of-truth.md
+++ b/docs/issues/2026-02-24_87_runtime-version-single-source-of-truth.md
@@ -1,0 +1,62 @@
+# Runtime Version: Single Source of Truth
+
+- **Date**: 2026-02-24
+- **Issue**: #87
+- **Status**: `open`
+- **Branch**: `feature/2026-02-24-quality-gap-issues`
+- **Priority**: `high`
+
+## Problem
+
+Runtime version reporting is inconsistent with published package versions.
+
+Current mismatch observed:
+- `pyproject.toml` / release tags / package registries reflect current versions (e.g. 0.6.x)
+- `src/mcp_tap/__init__.py` still hardcodes `__version__ = "0.1.0"`
+
+This weakens runtime traceability and release diagnostics.
+
+## Context
+
+- Module affected: `src/mcp_tap/__init__.py`
+- Release and publish workflows are healthy, but version introspection in runtime is stale
+- Smoke tests currently tolerate this legacy mismatch and should be corrected
+
+## Root Cause
+
+Version metadata is maintained in release files (`pyproject.toml`, npm wrapper), but runtime
+`__version__` remained hardcoded from early project stage.
+
+## Solution
+
+Implement single-source runtime version resolution:
+
+1. Resolve package version through `importlib.metadata.version("mcp-tap")` when installed
+2. Define deterministic fallback for local/source execution where metadata is unavailable
+3. Remove hardcoded legacy constant from runtime path
+4. Update smoke tests to validate runtime version behavior robustly
+
+## Files Changed
+
+- `src/mcp_tap/__init__.py` — dynamic runtime version resolution
+- `tests/smoke_test.py` — align version assertion with packaging reality
+- `tests/test_models.py` or dedicated version test module — fallback/install-path coverage
+- `docs/issues/2026-02-24_87_runtime-version-single-source-of-truth.md` — issue tracking
+
+## Verification
+
+- [ ] Tests pass: `pytest tests/`
+- [ ] Linter passes: `ruff check src/ tests/`
+- [ ] `mcp_tap.__version__` matches installed distribution version
+- [ ] Local source execution fallback documented and tested
+
+## Lessons Learned
+
+(Complete after delivery)
+
+## References
+
+- Python `importlib.metadata`:
+  - https://docs.python.org/3/library/importlib.metadata.html
+- Python packaging metadata:
+  - https://packaging.python.org/en/latest/specifications/core-metadata/

--- a/docs/issues/2026-02-24_88_cross-client-e2e-matrix.md
+++ b/docs/issues/2026-02-24_88_cross-client-e2e-matrix.md
@@ -1,0 +1,70 @@
+# Cross-Client E2E Compatibility Matrix
+
+- **Date**: 2026-02-24
+- **Issue**: #88
+- **Status**: `open`
+- **Branch**: `feature/2026-02-24-quality-gap-issues`
+- **Priority**: `high`
+
+## Problem
+
+Current coverage is strong in unit/integration/release checks, but we still lack a robust,
+continuous end-to-end matrix focused on client-specific compatibility paths.
+
+Risk: regressions can pass current tests while breaking one client path (`claude_code`, `cursor`,
+`windsurf`) due to transport/config differences.
+
+## Context
+
+- Affected modules:
+  - `src/mcp_tap/tools/configure.py`
+  - `src/mcp_tap/tools/verify.py`
+  - `src/mcp_tap/tools/health.py`
+  - client detection/config reader/writer adapters
+- Prior work added matrix foundations and release validation, but not full workflow E2E per client
+  as a permanent quality gate.
+
+## Root Cause
+
+Compatibility logic is spread across transport, config serialization, and drift verification layers.
+Without a true workflow matrix per client, cross-layer regressions can be missed.
+
+## Solution
+
+Add a dedicated E2E matrix suite with full client workflows:
+
+1. For each client profile (`claude_code`, `cursor`, `windsurf`):
+   - configure server
+   - verify lockfile/config drift
+   - run health check
+   - cleanup/remove
+2. Cover transport scenarios:
+   - native HTTP path
+   - fallback (`mcp-remote`) path
+   - mixed multi-client path in one operation
+3. Add CI matrix job with clear failure artifacts/logs
+4. Define optional scheduled/manual real-client validation if hosted CI cannot reproduce all
+   environment constraints
+
+## Files Changed
+
+- `tests/test_release_client_matrix.py` (or new `tests/e2e_clients/`) — expanded E2E suite
+- `.github/workflows/ci.yml` — E2E matrix lane(s)
+- `docs/issues/2026-02-24_88_cross-client-e2e-matrix.md` — issue tracking
+
+## Verification
+
+- [ ] Tests pass: `pytest tests/`
+- [ ] Linter passes: `ruff check src/ tests/`
+- [ ] E2E matrix covers all three clients
+- [ ] Mixed-client transport scenario validated in CI
+- [ ] CI blocks merge on client compatibility regressions
+
+## Lessons Learned
+
+(Complete after delivery)
+
+## References
+
+- GitHub Actions matrix jobs:
+  - https://docs.github.com/actions/using-jobs/using-a-matrix-for-your-jobs

--- a/docs/issues/2026-02-24_89_production-quality-feedback-loop.md
+++ b/docs/issues/2026-02-24_89_production-quality-feedback-loop.md
@@ -1,0 +1,76 @@
+# Production Recommendation Quality Feedback Loop
+
+- **Date**: 2026-02-24
+- **Issue**: #89
+- **Status**: `open`
+- **Branch**: `feature/2026-02-24-quality-gap-issues`
+- **Priority**: `high`
+
+## Problem
+
+Recommendation quality is currently validated offline (benchmark gate), but not measured
+systematically in production usage outcomes.
+
+Without online feedback, we cannot reliably detect:
+- quality regressions that benchmark fixtures do not capture
+- real acceptance behavior shifts after ranking changes
+- version-over-version impact on recommendation usefulness
+
+## Context
+
+- Existing benchmark infrastructure is strong for offline guardrails
+- Missing layer: opt-in production telemetry + aggregation for decision-quality metrics
+- Product goal (“best MCPs for each project”) benefits from real acceptance/rejection signals
+
+## Root Cause
+
+Current quality loop ends at offline evaluation and CI thresholds. No structured online event model
+exists to close the loop with real-world outcomes.
+
+## Solution
+
+Implement an opt-in production quality loop:
+
+1. Event schema (privacy-safe)
+   - recommendations shown
+   - recommendation accepted/configured
+   - recommendation rejected/ignored
+   - query metadata + ranked snapshot (non-sensitive)
+2. Metric aggregation
+   - acceptance@k
+   - top-1 conversion
+   - off-intent rejection rate
+   - stability/drift indicators by release version
+3. Reporting
+   - periodic report artifact
+   - version-segmented trend analysis
+4. Governance
+   - explicit opt-in policy
+   - no secrets/source leakage
+   - progressive release gates (warn-first, block later)
+
+## Files Changed
+
+- `src/mcp_tap/benchmark/` (extend metrics and reporting)
+- potential new telemetry module (if accepted in architecture)
+- docs for privacy policy and opt-in controls
+- `docs/issues/2026-02-24_89_production-quality-feedback-loop.md` — issue tracking
+
+## Verification
+
+- [ ] Tests pass: `pytest tests/`
+- [ ] Linter passes: `ruff check src/ tests/`
+- [ ] Event schema validated via tests
+- [ ] Synthetic data produces stable quality report output
+- [ ] Version-based trend segmentation works
+
+## Lessons Learned
+
+(Complete after delivery)
+
+## References
+
+- Offline relevance evaluation framing:
+  - https://www.pinecone.io/learn/offline-evaluation/
+- Ranking quality metric background:
+  - https://www.evidentlyai.com/ranking-metrics/ndcg-metric


### PR DESCRIPTION
## Summary
- add four new issue docs with mandatory issue-id naming in `docs/issues/`
- cover the next quality backlog items:
  - #86 semantic precision v2 (off-intent suppression)
  - #87 runtime version single source of truth
  - #88 cross-client E2E matrix
  - #89 production quality feedback loop
- include implementation direction, acceptance criteria, and validation plan for each item

## Notes
- documentation-only PR
- GitHub issues #86-#89 were opened first, then tracked locally per process
