### PR TITLE
Release v0.6.7: bump package versions

### DIFF
--- a/docs/issues/2026-02-24_95_release-v067.md
+++ b/docs/issues/2026-02-24_95_release-v067.md
@@ -1,0 +1,50 @@
+# Release v0.6.7
+
+- **Date**: 2026-02-24
+- **Issue**: #95
+- **Status**: `in_progress`
+- **Branch**: `fix/2026-02-24-release-v067`
+- **Priority**: `high`
+
+## Problem
+
+After merging PRs #91, #92, #93, and #94, we need a clean release cut so users can install the
+new capabilities via PyPI/npm and validate in a real smoke flow.
+
+## Context
+
+- Affected layers:
+  - release metadata/versioning
+  - publish pipeline (PyPI + npm)
+- Current latest public release before this task: `v0.6.6`
+- New merged scope includes semantic precision hardening, runtime version source-of-truth, client
+  E2E matrix gate, and production feedback loop.
+
+## Root Cause
+
+Release was pending after merging the feature/fix PR batch.
+
+## Solution
+
+1. Bump project version to `0.6.7` in release metadata files.
+2. Validate with lint/tests.
+3. Merge release PR to `main`.
+4. Push `v0.6.7` tag to trigger publish workflow.
+5. Confirm publish jobs and run smoke from published version.
+
+## Files Changed
+
+- `pyproject.toml` — bump Python package version to `0.6.7`
+- `npm-wrapper/package.json` — keep wrapper metadata aligned with release version
+- `docs/issues/2026-02-24_95_release-v067.md` — release tracking
+
+## Verification
+
+- [x] Tests pass: `uv run pytest tests/ -q`
+- [x] Linter passes: `uv run ruff check src/ tests/`
+- [ ] Tag `v0.6.7` published successfully (PyPI + npm workflows green)
+- [ ] Real smoke validates published version install/run
+
+## Lessons Learned
+
+(Fill after completion)

--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-tap",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant.",
   "keywords": [
     "mcp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-tap"
-version = "0.6.6"
+version = "0.6.7"
 description = "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump Python package version to `0.6.7` in `pyproject.toml`
- bump npm wrapper metadata version to `0.6.7` in `npm-wrapper/package.json`
- add release tracking doc for issue #95

## Validation
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run pytest tests/ -q`

Closes #95
