### PR TITLE
Archive release issue doc for v0.6.7

### DIFF
--- a/docs/issues/resolved/2026-02-24_95_release-v067.md
+++ b/docs/issues/resolved/2026-02-24_95_release-v067.md
@@ -2,7 +2,7 @@
 
 - **Date**: 2026-02-24
 - **Issue**: #95
-- **Status**: `in_progress`
+- **Status**: `done`
 - **Branch**: `fix/2026-02-24-release-v067`
 - **Priority**: `high`
 
@@ -42,9 +42,11 @@ Release was pending after merging the feature/fix PR batch.
 
 - [x] Tests pass: `uv run pytest tests/ -q`
 - [x] Linter passes: `uv run ruff check src/ tests/`
-- [ ] Tag `v0.6.7` published successfully (PyPI + npm workflows green)
-- [ ] Real smoke validates published version install/run
+- [x] Tag `v0.6.7` published successfully (PyPI + npm workflows green)
+- [x] Real smoke validates published version install/run
 
 ## Lessons Learned
 
-(Fill after completion)
+- Always cut release branch from `origin/main` (not local `main`) to avoid stale version confusion.
+- Keep Python and npm wrapper version metadata aligned before tag push to avoid publish drift.
+- Real smoke should validate both registry availability and executable behavior from published artifact.


### PR DESCRIPTION
## Summary
- mark release tracking doc #95 as done
- move `docs/issues/2026-02-24_95_release-v067.md` to `docs/issues/resolved/`
- record publish + smoke verification in the issue document

## Validation
- release tag `v0.6.7` published
- publish workflow run `22372745244` succeeded (PyPI + npm)
- smoke real passed with published package `mcp-tap==0.6.7`
