### PR TITLE
Release v0.6.8: bump package versions

### DIFF
--- a/docs/issues/2026-02-25_107_release-v068.md
+++ b/docs/issues/2026-02-25_107_release-v068.md
@@ -1,0 +1,50 @@
+# Release v0.6.8 (Cache Fallback + Configure Dry-Run)
+
+- **Date**: 2026-02-25
+- **Issue**: #107
+- **Status**: `open`
+- **Branch**: `fix/2026-02-25-release-v068`
+- **Priority**: `high`
+
+## Problem
+
+Changes from PR #106 are merged in `main`, but no release has been cut yet. Users cannot install
+these improvements from package registries.
+
+## Context
+
+- Last release is `v0.6.7`.
+- PR #106 added:
+  - search cache fallback metadata (`#104`)
+  - `configure_server(dry_run=True)` preflight (`#105`)
+- Release process requires version bump, validation, tag publish, and smoke.
+
+## Root Cause
+
+Release cadence depends on an explicit bump/tag workflow after merge.
+
+## Solution
+
+1. Bump versions to `0.6.8`.
+2. Validate with lint + tests.
+3. Open/merge release PR.
+4. Publish tag `v0.6.8`.
+5. Verify PyPI/npm availability and execute real smoke.
+
+## Files Changed
+
+- `docs/issues/2026-02-25_107_release-v068.md` — release tracking.
+
+## Verification
+
+- [ ] Baseline tests pass before changes: `uv run pytest tests/ -q`
+- [ ] Post-change tests pass: `uv run pytest tests/ -q`
+- [ ] Linter passes: `uv run ruff check src/ tests/`
+- [ ] Ruff format check passes: `uv run ruff format --check src/ tests/`
+- [ ] Tag `v0.6.8` published
+- [ ] Registry availability confirmed (PyPI and npm)
+- [ ] Smoke real executed from published version
+
+## Lessons Learned
+
+(Complete after release)

--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-tap",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant.",
   "keywords": [
     "mcp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-tap"
-version = "0.6.7"
+version = "0.6.8"
 description = "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -310,7 +310,7 @@ wheels = [
 
 [[package]]
 name = "mcp-tap"
-version = "0.6.7"
+version = "0.6.8"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- bump `pyproject.toml` version to `0.6.8`
- bump `npm-wrapper/package.json` version to `0.6.8`
- refresh `uv.lock` package version entry (`mcp-tap v0.6.8`)
- add release issue tracker `docs/issues/2026-02-25_107_release-v068.md`

## Validation
- `uv run pytest tests/ -q` -> 1288 passed
- `uv run ruff check src/ tests/` -> pass
- `uv run ruff format --check src/ tests/` -> pass

Closes #107
