### PR TITLE
Update release: cut v0.6.9

### DIFF
--- a/docs/issues/2026-02-25_112_release-v069.md
+++ b/docs/issues/2026-02-25_112_release-v069.md
@@ -1,0 +1,43 @@
+# Release v0.6.9 (GitHub Maturity Fallback + Transparency)
+
+- **Date**: 2026-02-25
+- **Issue**: #112
+- **Status**: `in_progress`
+- **Branch**: `fix/2026-02-25-release-v069`
+- **Priority**: `high`
+
+## Problem
+
+PR #111 is merged in `main`, but no package release has been cut yet. Users cannot consume the new GitHub maturity fallback/transparency behavior from registries.
+
+## Context
+
+- Current version in `main`: `0.6.8`
+- PR #111 introduced improvements in GitHub metadata auth fallback and degraded maturity transparency
+- Release workflow requires: version bump, validation, PR merge, tag/release publish, registry verification, smoke real
+
+## Root Cause
+
+Release publishing is a separate explicit step after feature PR merge.
+
+## Solution
+
+(To be filled after implementation)
+
+## Files Changed
+
+- `docs/issues/2026-02-25_112_release-v069.md` — release tracking document.
+
+## Verification
+
+- [ ] Baseline tests pass: `uv run pytest tests/ -q`
+- [ ] Post-change tests pass: `uv run pytest tests/ -q`
+- [ ] Linter passes: `uv run ruff check src/ tests/`
+- [ ] Ruff format check passes: `uv run ruff format --check src/ tests/`
+- [ ] Tag `v0.6.9` published
+- [ ] PyPI/npm availability confirmed
+- [ ] Smoke real executed from published artifacts
+
+## Lessons Learned
+
+(Complete after implementation)

--- a/npm-wrapper/package.json
+++ b/npm-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-tap",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant.",
   "keywords": [
     "mcp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-tap"
-version = "0.6.8"
+version = "0.6.9"
 description = "The last MCP server you install by hand. Discover, install, and configure MCP servers from inside your AI assistant."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -310,7 +310,7 @@ wheels = [
 
 [[package]]
 name = "mcp-tap"
-version = "0.6.8"
+version = "0.6.9"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- bump project version to `0.6.9` in `pyproject.toml`
- bump npm wrapper version to `0.6.9` in `npm-wrapper/package.json`
- update lock metadata to `0.6.9` in `uv.lock`
- add release tracking issue doc for #112

## Validation
- uv run pytest tests/ -q
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
